### PR TITLE
Update container to Anaconda 2025.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Container Infrastructure** (`ghcr.io/quantecon/quantecon:latest`)
   - Ubuntu 24.04 LTS + TexLive (latest) + Miniconda + Python 3.13
-  - Anaconda 2025.06 metapackage (numpy, scipy, pandas, matplotlib, jupyter)
+  - Anaconda 2025.12 metapackage (numpy, scipy, pandas, matplotlib, jupyter)
   - Jupyter Book 1.0.4post1 + sphinx extensions
   - Weekly automated builds (Monday 2am UTC)
   - CPU-focused for initial rollout

--- a/containers/quantecon/README.md
+++ b/containers/quantecon/README.md
@@ -12,7 +12,7 @@ ghcr.io/quantecon/quantecon:latest
 - Ubuntu 24.04 LTS
 - TexLive (latest from Ubuntu 24.04 repos)
 - Miniconda with Python 3.13
-- Anaconda 2025.06 (numpy, scipy, pandas, matplotlib, jupyter, etc.)
+- Anaconda 2025.12 (numpy, scipy, pandas, matplotlib, jupyter, etc.)
 - Jupyter Book build tools
 - LaTeX build tools (latexmk, xindy, dvipng)
 
@@ -104,7 +104,7 @@ conda list        # See all packages
 
 ### Installed Packages
 
-**Base Environment (Anaconda 2025.06):**
+**Base Environment (Anaconda 2025.12):**
 - NumPy, SciPy, Pandas - Scientific computing
 - Matplotlib, Seaborn - Visualization
 - NetworkX - Network analysis

--- a/containers/quantecon/environment.yml
+++ b/containers/quantecon/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
 dependencies:
   - python=3.13
-  - anaconda=2025.06  # Includes: numpy, scipy, pandas, matplotlib, seaborn, sympy, jupyter, jupyterlab, ipywidgets, networkx
+  - anaconda=2025.12  # Includes: numpy, scipy, pandas, matplotlib, seaborn, sympy, jupyter, jupyterlab, ipywidgets, networkx
   - pip
   - pip:
     # Jupyter Book build tools

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -16,7 +16,7 @@ This repository contains **reusable GitHub Actions composite actions** for build
 **✅ COMPLETED (November 20, 2025):**
 - Container infrastructure (`ghcr.io/quantecon/quantecon:latest`)
   - Ubuntu 24.04 LTS + TexLive + Miniconda + Python 3.13
-  - Anaconda 2025.06 metapackage (base scientific stack)
+  - Anaconda 2025.12 metapackage (base scientific stack)
   - Jupyter Book 1.0.4post1 + extensions
   - Weekly automated builds (Monday 2am UTC)
 - Composite actions:
@@ -115,7 +115,7 @@ quantecon/actions/
 - Ubuntu 24.04 LTS base
 - TexLive (latest from Ubuntu repos)
 - Miniconda + Python 3.13
-- Anaconda 2025.06 (numpy, scipy, pandas, matplotlib, jupyter)
+- Anaconda 2025.12 (numpy, scipy, pandas, matplotlib, jupyter)
 - Jupyter Book 1.0.4post1 + extensions
 
 **Usage in workflows:**
@@ -260,7 +260,7 @@ Single container for all CPU lectures:
 
 ### Why Anaconda Metapackage?
 
-Anaconda 2025.06 includes most common packages:
+Anaconda 2025.12 includes most common packages:
 - numpy, scipy, pandas, matplotlib, jupyter
 - Eliminates explicit dependencies
 - Faster conda solve times

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ Our next-generation CI/CD system combines three complementary elements:
 **Pre-built Docker images solve the LaTeX bottleneck:**
 
 - **Images:** `ghcr.io/quantecon/quantecon:latest` (CPU only - Phase 1)
-- **Contents:** Ubuntu 24.04 LTS + TexLive (latest) + Miniconda + Anaconda 2025.06 base + Jupyter Book tools
+- **Contents:** Ubuntu 24.04 LTS + TexLive (latest) + Miniconda + Anaconda 2025.12 base + Jupyter Book tools
 - **Build:** Weekly automated builds via GitHub Actions (Monday 2am UTC)
 - **Registry:** GitHub Container Registry (GHCR) - free for public repos
 - **Size:** ~2 GB (pulled once, cached by GitHub Actions runners)

--- a/docs/CONTAINER-GUIDE.md
+++ b/docs/CONTAINER-GUIDE.md
@@ -10,7 +10,7 @@ Quick guide for using QuantEcon container infrastructure.
 - Ubuntu 24.04 LTS
 - TexLive (latest from Ubuntu repos)
 - Miniconda + Python 3.13
-- Anaconda 2025.06 (numpy, scipy, pandas, matplotlib, jupyter)
+- Anaconda 2025.12 (numpy, scipy, pandas, matplotlib, jupyter)
 - Jupyter Book 1.0.4post1 + extensions
 
 **Updates:** Weekly automated builds (Monday 2am UTC)

--- a/setup-environment/README.md
+++ b/setup-environment/README.md
@@ -40,7 +40,7 @@ steps:
     run: conda env update -f environment.yml
 ```
 
-**Note:** When using `ghcr.io/quantecon/quantecon:latest` container, the `setup-environment` action is not needed. The container includes LaTeX, Miniconda, and Anaconda 2025.06 base packages. Only lecture-specific packages need installation.
+**Note:** When using `ghcr.io/quantecon/quantecon:latest` container, the `setup-environment` action is not needed. The container includes LaTeX, Miniconda, and Anaconda 2025.12 base packages. Only lecture-specific packages need installation.
 
 ## Inputs
 


### PR DESCRIPTION
## Summary

Updates the QuantEcon container to use Anaconda 2025.12 (from 2025.06).

## Changes

### Container Definition
- **`containers/quantecon/environment.yml`**: Updated `anaconda=2025.06` → `anaconda=2025.12`

### Documentation Updates
All references to the Anaconda version have been updated:
- `docs/ARCHITECTURE.md`
- `docs/CONTAINER-GUIDE.md`
- `containers/quantecon/README.md`
- `setup-environment/README.md`
- `CHANGELOG.md`
- `copilot-instructions.md`

## What's New in Anaconda 2025.12

The December 2025 release includes updated versions of core scientific packages. See [Anaconda release notes](https://docs.anaconda.com/anaconda/release-notes/) for details.

## Testing

After merging, the container will be rebuilt automatically via the `build-containers.yml` workflow. The new container can be tested with:

```bash
docker pull ghcr.io/quantecon/quantecon:latest
docker run --rm ghcr.io/quantecon/quantecon:latest conda list | grep anaconda
```

## Related

This should be merged after PR #6 (documentation cleanup).