### PR TITLE
feat(build-lectures): GitHub native build cache for fast PR builds

### DIFF
--- a/build-lectures/action.yml
+++ b/build-lectures/action.yml
@@ -23,17 +23,34 @@ inputs:
     description: 'Enable notebook execution caching'
     required: false
     default: 'true'
+  use-build-cache:
+    description: 'Restore _build directory from GitHub cache before building (for fast incremental PR builds)'
+    required: false
+    default: 'false'
 
 outputs:
   build-path:
     description: 'Path to the build output directory'
     value: ${{ steps.build.outputs.build-path }}
+  build-cache-hit:
+    description: 'Whether the build cache was restored'
+    value: ${{ steps.build-cache.outputs.cache-hit }}
 
 runs:
   using: "composite"
   steps:
+    - name: Restore build cache
+      if: inputs.use-build-cache == 'true'
+      uses: actions/cache/restore@v4
+      id: build-cache
+      with:
+        path: _build
+        key: build-${{ hashFiles('environment.yml') }}
+        restore-keys: |
+          build-
+
     - name: Cache Jupyter execution
-      if: inputs.cache-notebook-execution == 'true'
+      if: inputs.cache-notebook-execution == 'true' && inputs.use-build-cache != 'true'
       uses: actions/cache@v4
       id: jupyter-cache
       with:
@@ -87,7 +104,8 @@ runs:
         echo "Builder: ${{ inputs.builder }}"
         echo "Source: ${{ inputs.source-dir }}"
         echo "Output: ${{ steps.build.outputs.build-path }}"
-        echo "Jupyter cache hit: ${{ steps.jupyter-cache.outputs.cache-hit }}"
+        echo "Build cache hit: ${{ steps.build-cache.outputs.cache-hit || 'N/A' }}"
+        echo "Jupyter cache hit: ${{ steps.jupyter-cache.outputs.cache-hit || 'N/A' }}"
         echo "::endgroup::"
         
         echo "::group::Build Artifacts"

--- a/docs/FUTURE-DEVELOPMENT.md
+++ b/docs/FUTURE-DEVELOPMENT.md
@@ -25,11 +25,6 @@ Features needed to fully replace current `lecture-python.myst` workflows:
   - Add `create-notebooks-zip: 'true'` to `build-lectures`
   - Or add `notebooks-zip` option to `publish-gh-pages` release assets
 
-- [ ] **Artifact-based Build Cache** (alternative to GitHub cache)
-  - Document pattern for using `dawidd6/action-download-artifact`
-  - Works better for large `_build/` directories
-  - Add example to MIGRATION-GUIDE.md
-
 ### Low Priority (Repo-Specific)
 
 - [ ] **Notebook Repository Sync**
@@ -39,6 +34,12 @@ Features needed to fully replace current `lecture-python.myst` workflows:
 
 ### Completed ✅
 
+- [x] **Build Cache for Fast PR Builds** (`build-lectures`)
+  - Uses GitHub native cache (faster than artifact-based)
+  - Cache key: `build-${{ hashFiles('environment.yml') }}`
+  - Auto-invalidates when environment changes
+  - Documented `cache.yml` pattern for cache generation
+  - Weekly scheduled + push trigger on env changes
 - [x] Native GitHub Pages deployment (no gh-pages branch)
 - [x] Release assets (tarball, checksum, manifest)
 - [x] Auto-generated asset names from repo

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -105,6 +105,16 @@ jobs:
     builder: 'jupyter'
 ```
 
+### Fast PR Builds (with Build Cache)
+
+```yaml
+- uses: quantecon/actions/build-lectures@v1
+  with:
+    use-build-cache: true  # Restore from main's cache
+```
+
+**Note:** Requires a `cache.yml` workflow to generate the cache. See [MIGRATION-GUIDE.md](MIGRATION-GUIDE.md#step-5-update-cacheyml).
+
 ### Preview with Custom URL
 
 ```yaml
@@ -129,7 +139,8 @@ jobs:
 | Action | Cache Key | Invalidates On |
 |--------|-----------|----------------|
 | `setup-environment` | `conda-{OS}-{hash(env.yml)}-{version}` | env.yml changes, manual bump |
-| `build-lectures` | `jupyter-cache-{OS}-{hash(lectures)}-{sha}` | lecture changes, new commit |
+| `build-lectures` (exec) | `jupyter-cache-{OS}-{hash(lectures)}-{sha}` | lecture changes, new commit |
+| `build-lectures` (build) | `build-{hash(environment.yml)}` | environment.yml changes |
 
 ## 🎯 Inputs Quick Reference
 
@@ -154,6 +165,7 @@ source-dir: 'lectures'           # Source directory
 output-dir: './'                 # Output base
 extra-args: '-W --keep-going'    # JB arguments
 cache-notebook-execution: 'true' # Enable exec cache
+use-build-cache: 'false'         # Restore _build from GitHub cache
 ```
 
 ### deploy-netlify


### PR DESCRIPTION
## Summary

Adds GitHub native cache support to `build-lectures` action for fast incremental PR builds.

## Changes

### `build-lectures/action.yml`
- New input: `use-build-cache` (default: `false`)
- New output: `build-cache-hit`
- Cache key: `build-${{ hashFiles('environment.yml') }}`
- Disables jupyter execution cache when build cache is used (avoids conflicts)

### Documentation
- **README.md**: Full documentation of build cache feature and `cache.yml` pattern
- **MIGRATION-GUIDE.md**: Updated `cache.yml` example with GitHub native cache
- **QUICK-REFERENCE.md**: Added `use-build-cache` input reference
- **FUTURE-DEVELOPMENT.md**: Marked build cache feature as complete

## How It Works

### Cache Generation (`cache.yml` pattern)

Repos create a `cache.yml` workflow with triggers:
- `schedule`: Weekly fresh rebuild with latest dependencies
- `workflow_dispatch`: Manual rebuild
- `push` (paths: `environment.yml`): Auto-rebuild when env changes merged to main

### PR Builds

```yaml
- uses: quantecon/actions/build-lectures@v1
  with:
    use-build-cache: true
```

1. Restores `_build` from GitHub cache (key: `build-{env-hash}`)
2. Falls back to `restore-keys: build-` if no exact match
3. jupyter-book does incremental build (only changed notebooks)

### Auto-Invalidation

Cache key includes `hashFiles('environment.yml')`:
- **PR without env change** → cache hit → fast build
- **PR with env change** → cache miss → full rebuild (tests new deps)
- **Env change merged** → push trigger rebuilds cache

## Benefits vs Artifact-Based Caching

| Aspect | GitHub Cache | Artifacts |
|--------|--------------|-----------|
| Restore speed | ✅ Faster (content-addressable) | Slower (zip/unzip) |
| Cross-branch | ✅ Via restore-keys | Via dawidd6 action |
| Complexity | ✅ Native `actions/cache` | More setup |
| Inspectable | Artifact uploaded alongside | Direct download |
| Storage | 10 GB repo limit | 500 MB default |

## Cache Size

Based on `lecture-python.myst`:
- `_build/` total: ~153 MB
- Well within 10 GB GitHub cache limit

## Testing

To test:
1. Create `cache.yml` in a test repo using documented pattern
2. Run workflow to generate cache
3. Open PR and verify `use-build-cache: true` restores cache
4. Check build summary shows `Build cache hit: true`