### PR TITLE
Rename deploy-netlify to preview-netlify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING**: Renamed `deploy-netlify` → `preview-netlify` to better reflect its purpose as a PR preview action (not production deployment)
+
 ### Added
 - **Container Infrastructure** (`ghcr.io/quantecon/quantecon:latest`)
   - Ubuntu 24.04 LTS + TexLive (latest) + Miniconda + Python 3.13

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Builds Jupyter Book lectures (HTML, PDF, notebooks) with unified error handling.
 
 **Features:** Cached builds, execution reports, multi-format support
 
-### 🌐 [`deploy-netlify`](./deploy-netlify)
+### 🌐 [`preview-netlify`](./preview-netlify)
 Deploys preview builds to Netlify for pull requests with smart PR comments.
 
 **Features:** Automatic changed-file detection, PR preview URLs, security-aware (skips forks)
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Required for deploy-netlify change detection
+          fetch-depth: 0  # Required for preview-netlify change detection
       
       # Flexible environment setup
       - uses: quantecon/actions/setup-environment@v1
@@ -68,7 +68,7 @@ jobs:
           builder: 'html'
           source-dir: 'lectures'
       
-      - uses: quantecon/actions/deploy-netlify@v1
+      - uses: quantecon/actions/preview-netlify@v1
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}

--- a/containers/quantecon/environment.yml
+++ b/containers/quantecon/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.13
   - anaconda=2025.12  # Includes: numpy, scipy, pandas, matplotlib, seaborn, sympy, jupyter, jupyterlab, ipywidgets, networkx
-  - nodejs>=20,<21    # Required for netlify-cli in deploy-netlify action (matches jupyterlab requirement)
+  - nodejs>=20,<21    # Required for netlify-cli in preview-netlify action (matches jupyterlab requirement)
   - pip
   - pip:
     # Jupyter Book build tools

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -22,7 +22,7 @@ This repository contains **reusable GitHub Actions composite actions** for build
 - Composite actions:
   - `setup-environment` - Flexible environment setup with optional LaTeX
   - `build-lectures` - Jupyter Book builds
-  - `deploy-netlify` - Netlify deployment
+  - `preview-netlify` - Netlify PR previews
   - `publish-gh-pages` - GitHub Pages publishing
 - Documentation:
   - docs/CONTAINER-GUIDE.md - Container usage
@@ -85,7 +85,7 @@ quantecon/actions/
 ├── build-lectures/                # Jupyter Book builds
 │   ├── action.yml
 │   └── README.md
-├── deploy-netlify/                # Netlify deployment
+├── preview-netlify/                # Netlify PR previews
 │   ├── action.yml
 │   └── README.md
 ├── publish-gh-pages/              # GitHub Pages publishing
@@ -165,13 +165,13 @@ jobs:
     builder: 'html'
 ```
 
-### 3. deploy-netlify
+### 3. preview-netlify
 
-**Purpose:** Deploys to Netlify (preview + production)
+**Purpose:** Deploys to Netlify for PR previews
 
 **Usage:**
 ```yaml
-- uses: quantecon/actions/deploy-netlify@main
+- uses: quantecon/actions/preview-netlify@main
   with:
     netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,7 +28,7 @@ Our next-generation CI/CD system combines three complementary elements:
 
 ```
 build-lectures/      → Build Jupyter Book + handle caching
-deploy-netlify/      → Deploy to Netlify (preview + production)
+preview-netlify/     → Deploy to Netlify for PR previews
 publish-gh-pages/    → Deploy to GitHub Pages
 ```
 
@@ -92,7 +92,7 @@ jobs:
       - run: jupyter-book build lectures/
       
       # Manual deployment
-      - uses: quantecon/actions/deploy-netlify@v1
+      - uses: quantecon/actions/preview-netlify@v1
         with:
           # ... many configuration options
 ```
@@ -117,7 +117,7 @@ jobs:
         id: build
       
       # Deploy preview (PR only)
-      - uses: quantecon/actions/deploy-netlify@v1
+      - uses: quantecon/actions/preview-netlify@v1
         if: github.event_name == 'pull_request'
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -270,8 +270,8 @@ quantecon/actions/
 │   ├── action.yml                 # Build + automatic caching
 │   └── README.md
 │
-├── deploy-netlify/                # Modular action
-│   ├── action.yml                 # Netlify deployment
+├── preview-netlify/                # Modular action
+│   ├── action.yml                 # Netlify PR preview deployment
 │   └── README.md
 │
 ├── publish-gh-pages/              # Modular action

--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -157,7 +157,7 @@ jobs:
           upload-failure-reports: true  # Upload reports if build fails
       
       # Deploy preview
-      - uses: quantecon/actions/deploy-netlify@v1
+      - uses: quantecon/actions/preview-netlify@v1
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -8,7 +8,7 @@ A cheat sheet for using QuantEcon composite actions in your workflows.
 |--------|---------|--------------|
 | `setup-environment` | Conda + Python + LaTeX + ML libs | ~5-6 min (cached) |
 | `build-lectures` | Jupyter Book builds | Varies (cached execution) |
-| `deploy-netlify` | PR preview deployment | ~1 min |
+| `preview-netlify` | PR preview deployment | ~1 min |
 | `publish-gh-pages` | GitHub Pages deployment | ~30 sec |
 
 ## 🚀 Quick Start
@@ -31,7 +31,7 @@ jobs:
           install-latex: 'true'
       - uses: quantecon/actions/build-lectures@v1
         id: build
-      - uses: quantecon/actions/deploy-netlify@v1
+      - uses: quantecon/actions/preview-netlify@v1
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
@@ -118,7 +118,7 @@ jobs:
 ### Preview with Custom URL
 
 ```yaml
-- uses: quantecon/actions/deploy-netlify@v1
+- uses: quantecon/actions/preview-netlify@v1
   with:
     netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
@@ -171,7 +171,7 @@ html-copy-notebooks: 'false'     # Copy notebooks to _build/html/_notebooks/
 upload-failure-reports: 'false'  # Upload reports on failure
 ```
 
-### deploy-netlify
+### preview-netlify
 
 ```yaml
 netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}  # Required
@@ -205,11 +205,11 @@ permissions:
 # Access: ${{ steps.build.outputs.build-path }}
 ```
 
-### deploy-netlify
+### preview-netlify
 
 ```yaml
 - id: netlify
-  uses: quantecon/actions/deploy-netlify@v1
+  uses: quantecon/actions/preview-netlify@v1
 
 # Access:
 # - ${{ steps.netlify.outputs.deploy-url }}
@@ -296,7 +296,7 @@ permissions:
 
 ```yaml
 # Netlify only (no GH Pages)
-- uses: quantecon/actions/deploy-netlify@v1
+- uses: quantecon/actions/preview-netlify@v1
 ```
 
 ### lecture-python-advanced.myst

--- a/preview-netlify/README.md
+++ b/preview-netlify/README.md
@@ -1,4 +1,4 @@
-# Deploy Netlify Preview Action
+# Preview Netlify Action
 
 Deploys QuantEcon lecture builds to Netlify for PR previews with smart comments showing direct links to changed pages.
 
@@ -13,7 +13,7 @@ Deploys QuantEcon lecture builds to Netlify for PR previews with smart comments 
 ## Usage
 
 ```yaml
-- uses: quantecon/actions/deploy-netlify@v1
+- uses: quantecon/actions/preview-netlify@v1
   with:
     netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
@@ -96,7 +96,7 @@ jobs:
         run: jb build lectures --path-output ./
 
       - name: Deploy Preview
-        uses: quantecon/actions/deploy-netlify@v1
+        uses: quantecon/actions/preview-netlify@v1
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}

--- a/preview-netlify/action.yml
+++ b/preview-netlify/action.yml
@@ -1,4 +1,4 @@
-name: 'Deploy Netlify Preview'
+name: 'Preview Netlify'
 description: 'Deploys lecture builds to Netlify for PR previews with smart comments showing changed pages'
 author: 'QuantEcon'
 


### PR DESCRIPTION
## Summary

Renames the `deploy-netlify` action to `preview-netlify` to better reflect its purpose as a **PR preview action**.

## Rationale

The action is specifically designed for **PR preview deployments**, not general production deployments:

1. **Accurately describes purpose** - Uses `pr-{number}` URL aliases, not production URLs
2. **Feature set is preview-focused**:
   - PR preview deployments with predictable URLs
   - Changed lecture detection for PR comments
   - Smart PR comment management
   - Security checks that skip forks/dependabot
3. **Distinguishes from production deploys** - Creates a logical pairing with `publish-gh-pages`:
   - `preview-netlify` = temporary PR previews
   - `publish-gh-pages` = permanent production deployment
4. **Semantic clarity** - The word "deploy" suggests general-purpose deployment, while "preview" clearly indicates temporary PR previews

## Breaking Change

⚠️ **This is a breaking change.** Any workflows using `quantecon/actions/deploy-netlify@...` will need to update to `quantecon/actions/preview-netlify@...`

## Changes

- Renamed directory: `deploy-netlify/` → `preview-netlify/`
- Updated action name in `action.yml`: "Deploy Netlify Preview" → "Preview Netlify"
- Updated all documentation references:
  - README.md
  - docs/ARCHITECTURE.md
  - docs/QUICK-REFERENCE.md
  - docs/MIGRATION-GUIDE.md
  - copilot-instructions.md
  - containers/quantecon/environment.yml (comment)
- Added changelog entry for the breaking change

## Migration

For any lecture repositories using the action, update:

```yaml
# Before
- uses: quantecon/actions/deploy-netlify@v1

# After
- uses: quantecon/actions/preview-netlify@v1
```

No input/output changes - just the action path.
