### PR TITLE
Fix changed lecture URLs based on _toc.yml location

### DIFF
--- a/preview-cloudflare/action.yml
+++ b/preview-cloudflare/action.yml
@@ -97,6 +97,16 @@ runs:
         else
           echo "changed-files=" >> $GITHUB_OUTPUT
         fi
+        
+        # Detect if _toc.yml is inside lectures-dir (strip dir from URL) or at root (keep dir)
+        # If _toc.yml is inside lectures-dir, Jupyter Book builds relative to that dir
+        if [ -f "${lectures_dir}/_toc.yml" ]; then
+          echo "strip-lectures-dir=true" >> $GITHUB_OUTPUT
+          echo "📁 _toc.yml found in ${lectures_dir}/ - will strip directory from URLs"
+        else
+          echo "strip-lectures-dir=false" >> $GITHUB_OUTPUT
+          echo "📁 _toc.yml not in ${lectures_dir}/ - will keep directory in URLs"
+        fi
 
     - name: Install Wrangler CLI
       if: steps.check-trust.outputs.skip != 'true'
@@ -162,6 +172,7 @@ runs:
           const deployUrl = '${{ steps.deploy.outputs.deploy-url }}';
           const changedFiles = `${{ steps.detect-changes.outputs.changed-files }}`;
           const lecturesDir = '${{ inputs.lectures-dir }}';
+          const stripLecturesDir = '${{ steps.detect-changes.outputs.strip-lectures-dir }}' === 'true';
           const prNumber = context.issue.number;
           const commitSha = '${{ github.event.pull_request.head.sha }}';
           const shortSha = commitSha.substring(0, 7);
@@ -180,9 +191,18 @@ runs:
               for (const file of files) {
                 const cleanFile = file.trim();
                 if (cleanFile) {
-                  const fileName = cleanFile.replace(`${lecturesDir}/`, '').replace('.md', '');
-                  const pageUrl = `${deployUrl}/${fileName}.html`;
-                  comment += `- [${fileName}](${pageUrl})\n`;
+                  // Determine URL path based on _toc.yml location
+                  // If _toc.yml is in lectures-dir, strip the dir (JB builds relative to it)
+                  // If _toc.yml is at root, keep the dir (JB preserves structure)
+                  let filePath;
+                  if (stripLecturesDir) {
+                    filePath = cleanFile.replace(`${lecturesDir}/`, '').replace('.md', '');
+                  } else {
+                    filePath = cleanFile.replace('.md', '');
+                  }
+                  const displayName = filePath.split('/').pop();  // Just filename for display
+                  const pageUrl = `${deployUrl}/${filePath}.html`;
+                  comment += `- [${displayName}](${pageUrl})\n`;
                 }
               }
               comment += '\n';

--- a/preview-netlify/action.yml
+++ b/preview-netlify/action.yml
@@ -94,6 +94,16 @@ runs:
         else
           echo "changed-files=" >> $GITHUB_OUTPUT
         fi
+        
+        # Detect if _toc.yml is inside lectures-dir (strip dir from URL) or at root (keep dir)
+        # If _toc.yml is inside lectures-dir, Jupyter Book builds relative to that dir
+        if [ -f "${lectures_dir}/_toc.yml" ]; then
+          echo "strip-lectures-dir=true" >> $GITHUB_OUTPUT
+          echo "📁 _toc.yml found in ${lectures_dir}/ - will strip directory from URLs"
+        else
+          echo "strip-lectures-dir=false" >> $GITHUB_OUTPUT
+          echo "📁 _toc.yml not in ${lectures_dir}/ - will keep directory in URLs"
+        fi
 
     - name: Install Netlify CLI
       if: steps.check-trust.outputs.skip != 'true'
@@ -148,6 +158,7 @@ runs:
           const deployUrl = '${{ steps.deploy.outputs.deploy-url }}';
           const changedFiles = `${{ steps.detect-changes.outputs.changed-files }}`;
           const lecturesDir = '${{ inputs.lectures-dir }}';
+          const stripLecturesDir = '${{ steps.detect-changes.outputs.strip-lectures-dir }}' === 'true';
           const prNumber = context.issue.number;
           const commitSha = '${{ github.event.pull_request.head.sha }}';
           const shortSha = commitSha.substring(0, 7);
@@ -166,9 +177,18 @@ runs:
               for (const file of files) {
                 const cleanFile = file.trim();
                 if (cleanFile) {
-                  const fileName = cleanFile.replace(`${lecturesDir}/`, '').replace('.md', '');
-                  const pageUrl = `${deployUrl}/${fileName}.html`;
-                  comment += `- [${fileName}](${pageUrl})\n`;
+                  // Determine URL path based on _toc.yml location
+                  // If _toc.yml is in lectures-dir, strip the dir (JB builds relative to it)
+                  // If _toc.yml is at root, keep the dir (JB preserves structure)
+                  let filePath;
+                  if (stripLecturesDir) {
+                    filePath = cleanFile.replace(`${lecturesDir}/`, '').replace('.md', '');
+                  } else {
+                    filePath = cleanFile.replace('.md', '');
+                  }
+                  const displayName = filePath.split('/').pop();  // Just filename for display
+                  const pageUrl = `${deployUrl}/${filePath}.html`;
+                  comment += `- [${displayName}](${pageUrl})\n`;
                 }
               }
               comment += '\n';


### PR DESCRIPTION
## Summary

Fixes #15 - Changed lecture URLs in PR comments were missing the directory path for projects where `_toc.yml` is at the root level.

## Problem

The URL construction assumed all projects have `_toc.yml` inside the lectures directory (like QuantEcon lectures), but some projects (like QuantMFR) have `_toc.yml` at the root level.

| Project | `_toc.yml` Location | Git Path | Expected URL |
|---------|---------------------|----------|--------------|
| QuantEcon | `lectures/_toc.yml` | `lectures/ar1.md` | `/ar1.html` |
| QuantMFR | `_toc.yml` (root) | `book/file.md` | `/book/file.html` |

## Solution

Auto-detect `_toc.yml` location and adjust URL construction accordingly:

- If `_toc.yml` is **inside** `lectures-dir`: Strip directory from URL (Jupyter Book builds relative to that dir)
- If `_toc.yml` is **at root**: Keep full path in URL (Jupyter Book preserves directory structure)

## Changes

- `preview-cloudflare/action.yml`: Add `_toc.yml` detection and conditional URL path handling
- `preview-netlify/action.yml`: Same changes for consistency

## Testing

This should be tested with:
1. A repo with `lectures/_toc.yml` (e.g., test-lecture-python-intro) - should strip `lectures/`
2. A repo with root-level `_toc.yml` (e.g., QuantMFR) - should keep directory path
