### PR TITLE
feat: add lecture validation tests for containers

### DIFF
--- a/.github/workflows/test-containers-lectures.yml
+++ b/.github/workflows/test-containers-lectures.yml
@@ -63,6 +63,7 @@ jobs:
     name: Test ${{ matrix.repo }}
     needs: setup
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     container:
       image: ghcr.io/quantecon/${{ needs.setup.outputs.container }}:latest


### PR DESCRIPTION
## Summary

Adds a new workflow to validate containers by running full lecture builds against all QuantEcon lecture repositories.

## What This Does

Tests the containers against:
- `lecture-python-programming.myst`
- `lecture-python-intro`
- `lecture-python-advanced.myst`
- `lecture-python.myst`

## Features

- **Automatic Trigger:** Runs after container builds complete (informational, not blocking)
- **Manual Dispatch:** Can select specific container and/or repos to test
- **Full Execution:** Uses `jb build . -n -W --keep-going` for strict validation
- **Parallel Testing:** All 4 repos test simultaneously
- **Artifacts:** Build outputs and execution reports uploaded for inspection
- **Summary:** Clear overview of results

## Workflow Behavior

| Trigger | Behavior |
|---------|----------|
| After container build | Tests all 4 repos with `quantecon-build` (lean) |
| Manual dispatch | Choose container and/or specific repos |

## Expected Build Times

These will be long-running tests (full notebook execution):
- `lecture-python-intro`: ~10-15 min
- `lecture-python-programming.myst`: ~15-20 min
- `lecture-python-advanced.myst`: ~15-20 min
- `lecture-python.myst`: ~30-45 min (largest)

## Future Considerations

- [ ] Add option to test containers *before* pushing to registry
- [ ] Container versioning for reproducible builds
- [ ] GPU testing for `lecture-python.myst`
- [ ] Smoke test option (subset of lectures) for faster validation

## Testing

After merge, can trigger manually:
```
gh workflow run test-containers-lectures.yml
```
