### PR TITLE
Remove hardcoded ML libs install from setup-environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **`setup-environment`**: Remove `install-ml-libs` and `ml-libs-version` inputs
+  - ML/GPU libraries (JAX, PyTorch, numpyro) should be specified in each repo's
+    `environment.yml` or `environment-update.yml` instead of being hardcoded in the action
+  - JAX now bundles its own CUDA toolkit via pip (`jax[cuda13]`), so system-level
+    CUDA installation is unnecessary — GPU drivers on the AMI are sufficient
+  - Removes pip cache step and hardcoded install step for ML libraries
+
 ## [0.5.2] - 2026-02-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Removed
-- **`setup-environment`**: Remove `install-ml-libs` and `ml-libs-version` inputs
+- **`setup-environment`**: Remove `install-ml-libs` and `ml-libs-version` inputs ⚠️ **BREAKING**
   - ML/GPU libraries (JAX, PyTorch, numpyro) should be specified in each repo's
     `environment.yml` or `environment-update.yml` instead of being hardcoded in the action
   - JAX now bundles its own CUDA toolkit via pip (`jax[cuda13]`), so system-level
     CUDA installation is unnecessary — GPU drivers on the AMI are sufficient
   - Removes pip cache step and hardcoded install step for ML libraries
+  - **Migration:** Repos using `install-ml-libs: 'true'` should move ML packages to
+    their `environment-update.yml` and remove the `install-ml-libs` input
 
 ## [0.5.2] - 2026-02-06
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -90,7 +90,7 @@ Once `lecture-dp` is running smoothly, migrate existing repos — CPU-only first
 | Feature | lecture-python.myst does | Our action | Status |
 |---------|-------------------------|------------|--------|
 | Environment setup on RunsOn AMI | `conda-incubator/setup-miniconda@v3` | `setup-environment` (marker detection) | ✅ Supported |
-| ML libs (JAX CUDA 13, numpyro) | `pip install -U "jax[cuda13]"` + numpyro | `setup-environment` (`install-ml-libs`) | ✅ Supported — verify CUDA 13 |
+| ML libs (JAX CUDA 13, numpyro) | `pip install -U "jax[cuda13]"` + numpyro | Repo's `environment.yml` / `environment-update.yml` | ✅ Repos manage their own ML packages |
 | HTML build | `jb build lectures -W --keep-going` | `build-lectures` (builder: html) | ✅ Supported |
 | PDF build | `jb build --builder pdflatex` | `build-lectures` (builder: pdflatex) | ✅ Supported |
 | Jupyter notebook build | `jb build --builder=custom --custom-builder=jupyter` | `build-lectures` (builder: jupyter) | ✅ Supported |
@@ -133,15 +133,7 @@ Our `publish-gh-pages` uses native OIDC-based deployment (`actions/deploy-pages`
 
 **Action:** Test a Pages deployment from a RunsOn runner.
 
-#### 3. Verify JAX CUDA 13 compatibility
-
-**Priority:** Medium
-
-Our `setup-environment` has `install-ml-libs: 'true'` which installs JAX and PyTorch. Need to verify the installed JAX version supports CUDA 13 and matches what the lectures expect.
-
-**Action:** Check `setup-environment` ML libs install commands against `jax[cuda13]` + numpyro.
-
-#### 4. Download Notebooks Zip
+#### 3. Download Notebooks Zip
 
 **Priority:** Medium — needed for `publish.yml` parity
 
@@ -154,7 +146,7 @@ Our `setup-environment` has `install-ml-libs: 'true'` which installs JAX and PyT
 
 **Recommendation:** Inline workflow step initially. Consider action feature if other repos need it.
 
-#### 5. Notebook Repository Sync
+#### 4. Notebook Repository Sync
 
 **Priority:** Low — `lecture-python.myst` specific
 
@@ -192,7 +184,6 @@ All features needed to fully replace current lecture-repo workflows:
 - [ ] **Notebook Repository Sync** — Document as inline workflow steps (too repo-specific for an action)
 - [ ] **Verify `actions/cache` on RunsOn** — Test cache save/restore on self-hosted GPU runners
 - [ ] **Verify OIDC Pages deployment from RunsOn** — Test native GH Pages deploy from self-hosted runners
-- [ ] **Verify JAX CUDA 13 install** — Confirm `install-ml-libs` matches `jax[cuda13]` + numpyro
 
 ### Completed ✅
 
@@ -207,7 +198,7 @@ All features needed to fully replace current lecture-repo workflows:
 - [x] Changed file detection for PR comments
 - [x] Conda environment caching (standard mode)
 - [x] LaTeX installation with requirements file
-- [x] JAX/PyTorch ML libs installation
+- [x] JAX/PyTorch ML libs — managed via repo `environment.yml` (not hardcoded in action)
 - [x] Multi-builder support (html, pdflatex, jupyter)
 - [x] Container-aware environment setup (marker file detection)
 - [x] Delta package installs (`environment-update` input)

--- a/containers/README.md
+++ b/containers/README.md
@@ -77,4 +77,6 @@ Both containers include a marker file at `/etc/quantecon-container` that allows 
 
 ## GPU Support
 
-GPU containers (for JAX/PyTorch CUDA) are not yet available. See [FUTURE-DEVELOPMENT.md](../docs/FUTURE-DEVELOPMENT.md) for roadmap.
+GPU builds use RunsOn with a custom Ubuntu AMI (not a container). The AMI includes NVIDIA drivers while ML libraries (JAX, PyTorch) bundle their own CUDA toolkit.
+
+**See:** [GPU-AMI-SETUP.md](../docs/GPU-AMI-SETUP.md) for AMI build instructions and driver requirements.

--- a/docs/GPU-AMI-SETUP.md
+++ b/docs/GPU-AMI-SETUP.md
@@ -1,0 +1,508 @@
+# GPU AMI Setup Guide
+
+Guide for building a RunsOn custom AMI for GPU-accelerated lecture builds (lecture-python.myst).
+
+---
+
+## Overview
+
+QuantEcon uses [RunsOn](https://runs-on.com) with a custom Ubuntu AMI for GPU builds. The AMI provides:
+- NVIDIA GPU drivers
+- Conda/Miniconda Python environment
+- LaTeX for PDF builds
+- Container mode marker file for `setup-environment` action
+
+**Key insight:** When using `jax[cuda13]` (bundled CUDA), you only need **GPU drivers** — the CUDA toolkit, cuDNN, and NCCL are bundled in the JAX pip wheel.
+
+---
+
+## System Requirements
+
+### Required: NVIDIA GPU Drivers
+
+**For JAX with CUDA 13 (current):**
+- **NVIDIA driver version >= 580** (Linux)
+- **GPU compute capability >= 7.5** (Turing+ architecture: RTX 20xx, A100, H100, etc.)
+
+**For JAX with CUDA 12 (legacy):**
+- **NVIDIA driver version >= 525** (Linux)
+- **GPU compute capability >= 5.2** (Maxwell+ architecture: GTX 900 series and newer)
+
+**Verify driver installation:**
+```bash
+nvidia-smi  # Should show driver version >= 580
+```
+
+### NOT Required: CUDA Toolkit Installation
+
+When repos use `pip install "jax[cuda13]"`, the wheel **bundles all CUDA libraries**:
+- ✅ CUDA toolkit (13.0) — bundled in wheel
+- ✅ cuDNN (9.8) — bundled in wheel
+- ✅ NCCL (2.19) — bundled in wheel
+
+**Do NOT install** via system package managers:
+- ❌ `apt-get install cuda`
+- ❌ `conda install cuda-toolkit`
+- ❌ `conda install cudnn`
+
+This eliminates "CUDA version hell" — the only system dependency is the NVIDIA driver.
+
+**Reference:** [JAX Installation - NVIDIA GPU](https://docs.jax.dev/en/latest/installation.html#nvidia-gpu)
+
+---
+
+## AMI Build Process
+
+### 1. Base OS
+
+Start with Ubuntu 24.04 LTS (recommended):
+
+```bash
+# Example: AWS EC2 base AMI
+ami-0c55b159cbfafe1f0  # Ubuntu 24.04 LTS, x86_64
+```
+
+Or use Packer to automate AMI builds from scratch.
+
+### 2. Install NVIDIA Drivers
+
+**Option 1: From Ubuntu repositories (simpler)**
+
+```bash
+sudo apt-get update
+sudo apt-get install -y nvidia-driver-580  # or nvidia-driver-latest
+```
+
+**Option 2: From NVIDIA's official repository (recommended for latest drivers)**
+
+```bash
+# Add NVIDIA package repository
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+sudo dpkg -i cuda-keyring_1.1-1_all.deb
+sudo apt-get update
+
+# Install latest driver (not the full CUDA toolkit)
+sudo apt-get install -y nvidia-driver-latest
+
+# Reboot to load driver
+sudo reboot
+```
+
+**Verify after reboot:**
+
+```bash
+nvidia-smi
+# Expected output:
+# +-----------------------------------------------------------------------------------------+
+# | NVIDIA-SMI 580.xx.xx              Driver Version: 580.xx.xx      CUDA Version: 13.0     |
+# +-----------------------------------------------------------------------------------------+
+# | GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+# ...
+```
+
+**Note:** The "CUDA Version" shown by `nvidia-smi` is the **maximum CUDA version the driver supports**, not an installed toolkit. JAX brings its own.
+
+### 3. Install Miniconda and Base Environment
+
+```bash
+# Download Miniconda
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh
+
+# Install to /opt/conda (system-wide)
+sudo bash /tmp/miniconda.sh -b -p /opt/conda
+
+# Add to PATH for all users
+echo 'export PATH="/opt/conda/bin:$PATH"' | sudo tee -a /etc/profile.d/conda.sh
+source /etc/profile.d/conda.sh
+
+# Initialize conda
+conda init bash
+
+# Update base environment
+conda update -y -n base conda
+conda install -y -n base python=3.13 pip
+```
+
+### 4. Install LaTeX (for PDF builds)
+
+```bash
+sudo apt-get install -y \
+  texlive-xetex \
+  texlive-fonts-recommended \
+  texlive-fonts-extra \
+  texlive-latex-extra \
+  latexmk \
+  xindy
+```
+
+### 5. Create Container Mode Marker File
+
+This allows `setup-environment` to detect the AMI and skip redundant installations:
+
+```bash
+sudo bash -c 'cat > /etc/quantecon-container << EOF
+quantecon-container
+image=quantecon_ubuntu2404
+variant=gpu
+build_date=$(date -Iseconds)
+nvidia_driver=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -1)
+EOF'
+```
+
+**Example marker content:**
+
+```
+quantecon-container
+image=quantecon_ubuntu2404
+variant=gpu
+build_date=2026-02-09T12:00:00+00:00
+nvidia_driver=580.13.03
+```
+
+### 6. Pre-install Common Scientific Packages (Optional)
+
+To speed up builds, pre-install common scientific Python packages in the base environment:
+
+```bash
+# Core scientific stack
+conda install -y -c conda-forge \
+  numpy scipy pandas matplotlib seaborn \
+  jupyter jupyterlab ipython ipykernel \
+  quantecon
+
+# Jupyter Book dependencies
+pip install -U \
+  jupyter-book \
+  jupytext \
+  sphinx-multitoc-numbering \
+  quantecon-book-theme
+```
+
+**Note:** Lecture-specific packages (JAX, PyTorch, numpyro) should be installed by each repo's workflow via `environment-update.yml`, not baked into the AMI. This keeps AMI builds simple and avoids version drift.
+
+### 7. Clean Up and Finalize
+
+```bash
+# Clean conda cache
+conda clean -y --all
+
+# Clean apt cache
+sudo apt-get clean
+sudo rm -rf /var/lib/apt/lists/*
+
+# Remove temporary files
+rm -rf /tmp/*
+
+# Clear shell history (for Packer builds)
+cat /dev/null > ~/.bash_history
+history -c
+```
+
+---
+
+## Packer Build Template (Example)
+
+```hcl
+# quantecon-gpu-ami.pkr.hcl
+packer {
+  required_plugins {
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = "~> 1"
+    }
+  }
+}
+
+source "amazon-ebs" "quantecon_gpu" {
+  ami_name      = "quantecon_ubuntu2404_gpu_{{timestamp}}"
+  instance_type = "g4dn.xlarge"  # GPU instance for driver testing
+  region        = "us-east-1"
+  
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/hvm-ssd/ubuntu-noble-24.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    owners      = ["099720109477"]  # Canonical
+    most_recent = true
+  }
+  
+  ssh_username = "ubuntu"
+  
+  tags = {
+    Name        = "quantecon-gpu-ubuntu2404"
+    Environment = "production"
+    Version     = "{{timestamp}}"
+  }
+}
+
+build {
+  sources = ["source.amazon-ebs.quantecon_gpu"]
+  
+  provisioner "shell" {
+    inline = [
+      # Update system
+      "sudo apt-get update",
+      "sudo apt-get upgrade -y",
+      
+      # Install NVIDIA driver
+      "wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb",
+      "sudo dpkg -i cuda-keyring_1.1-1_all.deb",
+      "sudo apt-get update",
+      "sudo apt-get install -y nvidia-driver-latest",
+      
+      # Install Miniconda
+      "wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh",
+      "sudo bash /tmp/miniconda.sh -b -p /opt/conda",
+      "echo 'export PATH=\"/opt/conda/bin:$PATH\"' | sudo tee -a /etc/profile.d/conda.sh",
+      "source /etc/profile.d/conda.sh",
+      "/opt/conda/bin/conda init bash",
+      
+      # Install LaTeX
+      "sudo apt-get install -y texlive-xetex texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra latexmk xindy",
+      
+      # Create marker file
+      "sudo bash -c 'cat > /etc/quantecon-container << EOF",
+      "quantecon-container",
+      "image=quantecon_ubuntu2404",
+      "variant=gpu",
+      "build_date=$(date -Iseconds)",
+      "nvidia_driver=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -1)",
+      "EOF'",
+      
+      # Clean up
+      "/opt/conda/bin/conda clean -y --all",
+      "sudo apt-get clean",
+      "sudo rm -rf /var/lib/apt/lists/*",
+    ]
+  }
+}
+```
+
+**Build the AMI:**
+
+```bash
+packer init quantecon-gpu-ami.pkr.hcl
+packer build quantecon-gpu-ami.pkr.hcl
+```
+
+---
+
+## Using the AMI in Workflows
+
+Once the AMI is built, reference it in RunsOn workflows:
+
+```yaml
+jobs:
+  build:
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: quantecon/actions/setup-environment@v1
+        with:
+          environment-update: 'environment-update.yml'
+        # Detects /etc/quantecon-container marker → skips Miniconda/LaTeX install
+      
+      - uses: quantecon/actions/build-lectures@v1
+```
+
+**Repo's `environment-update.yml` specifies ML packages:**
+
+```yaml
+name: quantecon
+channels:
+  - conda-forge
+dependencies:
+  - quantecon
+  - pip:
+    - jax[cuda13]      # Bundles CUDA 13.0 + cuDNN 9.8 + NCCL 2.19
+    - numpyro
+    - torch            # PyTorch also bundles its own CUDA
+    - quantecon-book-theme
+```
+
+---
+
+## Verification
+
+After building the AMI, launch a test EC2 instance to verify:
+
+```bash
+# 1. Check NVIDIA driver
+nvidia-smi
+# Should show driver >= 580, GPU detected
+
+# 2. Check marker file
+cat /etc/quantecon-container
+# Should show image=quantecon_ubuntu2404, variant=gpu
+
+# 3. Check conda
+conda --version
+# Should show Miniconda
+
+# 4. Test JAX install (simulates workflow)
+conda create -n test python=3.13 -y
+conda activate test
+pip install "jax[cuda13]"
+python -c "import jax; print(jax.devices())"
+# Should show: [cuda(id=0)]
+
+# 5. Check LaTeX
+xelatex --version
+# Should show XeTeX version
+```
+
+---
+
+## Maintenance
+
+### Updating the AMI
+
+**When to rebuild:**
+- NVIDIA releases new driver versions (quarterly-ish)
+- Major Python version updates (e.g., 3.13 → 3.14)
+- LaTeX package requirements change
+- Security updates for base OS
+
+**Versioning:**
+- Use timestamp or semantic versioning in AMI name
+- Tag AMIs: `quantecon_ubuntu2404_gpu_20260209`
+- Keep 2-3 previous versions for rollback
+
+### Driver Updates
+
+JAX supports forward compatibility — newer drivers can run older CUDA versions. To stay current:
+
+```bash
+# On the AMI
+sudo apt-get update
+sudo apt-get install --only-upgrade nvidia-driver-latest
+```
+
+Then rebuild the AMI and update RunsOn configuration.
+
+---
+
+## Troubleshooting
+
+### `nvidia-smi` not found after reboot
+
+**Cause:** Driver not loaded
+
+**Fix:**
+```bash
+# Check driver installation
+dpkg -l | grep nvidia-driver
+
+# Reload modules
+sudo modprobe nvidia
+
+# Reboot if needed
+sudo reboot
+```
+
+### JAX doesn't detect GPU
+
+**Cause:** Usually driver version too old
+
+**Fix:**
+```bash
+# Check JAX requirements
+python -c "import jax; print(jax.devices())"
+
+# If shows [cpu], check driver
+nvidia-smi
+
+# Ensure driver >= 580 for CUDA 13
+sudo apt-get install --only-upgrade nvidia-driver-latest
+```
+
+### "libcuda.so.1: cannot open shared object file"
+
+**Cause:** CUDA driver library not in library path
+
+**Fix:**
+```bash
+# Find libcuda.so
+find /usr -name libcuda.so.1 2>/dev/null
+
+# Add to LD_LIBRARY_PATH (typically not needed with proper driver install)
+export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+```
+
+---
+
+## Architecture Notes
+
+### Why AMI instead of GPU Container?
+
+**Advantages of RunsOn AMI:**
+- `actions/cache` works normally (containers have caching limitations)
+- Direct hardware access, no virtualization overhead
+- Simpler NVIDIA driver management (no Docker daemon configuration)
+- Compatible with all GitHub Actions features
+
+**Disadvantages:**
+- Requires AMI maintenance and rebuilds
+- Slower to iterate vs pulling a container
+- Per-cloud-provider setup
+
+**Future:** If GitHub launches official GPU runners, we may sunset the custom AMI approach. See [FUTURE-DEVELOPMENT.md](FUTURE-DEVELOPMENT.md).
+
+### JAX Bundled CUDA vs System CUDA
+
+When you `pip install "jax[cuda13]"`, you get:
+- `jaxlib` with CUDA runtime embedded
+- Python extension modules linked against bundled CUDA
+- All JAX kernels pre-compiled for CUDA 13
+
+**How it works:**
+1. JAX wheel includes `libcudart.so.13`, `libcublas.so.13`, etc. in the wheel
+2. At runtime, JAX loads these libraries via Python's import mechanism
+3. These libraries talk to `/usr/lib/x86_64-linux-gnu/libcuda.so.1` (from NVIDIA driver)
+4. Driver talks to GPU hardware
+
+**Layer separation:**
+```
+┌─────────────────────────┐
+│   JAX Python Package    │  pip install "jax[cuda13]"
+├─────────────────────────┤
+│   Bundled CUDA Toolkit  │  Included in wheel (13.0)
+│   (cublas, cudnn, etc)  │
+├─────────────────────────┤
+│   NVIDIA Driver (580+)  │  System install (apt-get)
+├─────────────────────────┤
+│   GPU Hardware (RTX)    │  RunsOn EC2 instance
+└─────────────────────────┘
+```
+
+Only the driver needs to be on the system. Everything above it comes from pip.
+
+---
+
+## References
+
+- [JAX Installation - NVIDIA GPU](https://docs.jax.dev/en/latest/installation.html#nvidia-gpu)
+- [NVIDIA Driver Downloads](https://www.nvidia.com/Download/index.aspx)
+- [CUDA Compatibility Guide](https://docs.nvidia.com/deploy/cuda-compatibility/)
+- [RunsOn Documentation](https://runs-on.com/guides/)
+- [Packer AWS Builder](https://developer.hashicorp.com/packer/plugins/builders/amazon)
+
+---
+
+## Quick Reference
+
+| Component | Required Version | Installation Method |
+|-----------|------------------|---------------------|
+| **NVIDIA Driver** | >= 580 (CUDA 13) | `apt-get install nvidia-driver-latest` |
+| **CUDA Toolkit** | N/A | Bundled in `jax[cuda13]` wheel |
+| **cuDNN** | N/A | Bundled in `jax[cuda13]` wheel |
+| **Python** | 3.13+ | Miniconda |
+| **GPU** | Compute 7.5+ | EC2 g4dn/p3/p4 instances |
+
+**One-liner test:**
+```bash
+python -c "import jax; print('GPU detected!' if jax.devices()[0].platform == 'gpu' else 'CPU only')"
+```

--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -145,7 +145,6 @@ jobs:
           environment: 'environment.yml'
           environment-name: 'quantecon'
           install-latex: 'true'
-          install-ml-libs: 'false'  # Set to 'true' for lecture-python.myst
       
       # Build lectures (with cache restore for fast incremental builds)
       - uses: quantecon/actions/restore-jupyter-cache@v1
@@ -310,7 +309,6 @@ jobs:
       - uses: quantecon/actions/setup-environment@v1
         with:
           install-latex: 'true'
-          install-ml-libs: 'false'  # Adjust per repo
       
       # Build PDF
       - uses: quantecon/actions/build-lectures@v1
@@ -353,11 +351,11 @@ jobs:
 
 ```yaml
 # In ci.yml, cache.yml, publish.yml:
+# ML packages (JAX, PyTorch, numpyro) are specified in the repo's
+# environment.yml or environment-update.yml, not in the action.
 - uses: quantecon/actions/setup-environment@v1
   with:
-    install-latex: 'true'
-    install-ml-libs: 'true'  # Enable ML libraries
-    ml-libs-version: 'jax062-torch-nightly-cuda12'  # For cache key
+    environment-update: 'environment-update.yml'
 
 # Also update runner if needed:
 jobs:
@@ -467,8 +465,7 @@ Before merging, verify:
 
 **Special requirements:**
 - GPU runners: `runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/..."`
-- ML libraries: Set `install-ml-libs: 'true'`
-- CUDA support: Uses JAX 0.6.2 with CUDA 12
+- ML libraries: Specified in repo's `environment.yml` / `environment-update.yml` (JAX, PyTorch, numpyro)
 
 **Example ci.yml excerpt:**
 ```yaml
@@ -480,9 +477,7 @@ jobs:
       
       - uses: quantecon/actions/setup-environment@v1
         with:
-          install-latex: 'true'
-          install-ml-libs: 'true'
-          ml-libs-version: 'jax062-torch-nightly-cuda12'
+          environment-update: 'environment-update.yml'
       
       - uses: quantecon/actions/restore-jupyter-cache@v1
         with:

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -6,7 +6,7 @@ A cheat sheet for using QuantEcon composite actions in your workflows.
 
 | Action | Purpose | Time Savings |
 |--------|---------|--------------|
-| `setup-environment` | Conda + Python + LaTeX + ML libs | ~5-6 min (cached) |
+| `setup-environment` | Conda + Python + LaTeX | ~5-6 min (cached) |
 | `build-lectures` | Jupyter Book builds | Varies (cached execution) |
 | `build-jupyter-cache` | Weekly cache generation (main branch) | Enables 80% faster CI |
 | `restore-jupyter-cache` | Read-only cache restore (PRs) | ~14 min (avoids full rebuild) |
@@ -118,14 +118,6 @@ jobs:
 
 ## 🔧 Common Customizations
 
-### Add ML Libraries (JAX/PyTorch)
-
-```yaml
-- uses: quantecon/actions/setup-environment@v1
-  with:
-    install-ml-libs: 'true'
-```
-
 ### Build PDF
 
 ```yaml
@@ -201,8 +193,6 @@ environment-name: 'quantecon'    # Conda env name
 cache-version: 'v1'              # Manual cache control
 install-latex: 'false'           # Install LaTeX (auto-disabled in container)
 latex-requirements-file: 'latex-requirements.txt'  # LaTeX packages list
-install-ml-libs: 'false'         # JAX/PyTorch/CUDA
-ml-libs-version: 'jax062-...'    # ML cache key
 ```
 
 **Outputs:** `container-mode`, `conda-cache-hit`
@@ -339,16 +329,16 @@ permissions:
 ### lecture-python.myst (GPU)
 
 ```yaml
+# ML packages (JAX, PyTorch) specified in repo's environment.yml
 - uses: quantecon/actions/setup-environment@v1
   with:
-    install-latex: 'true'
-    install-ml-libs: 'true'  # JAX + PyTorch
+    environment-update: 'environment-update.yml'
 ```
 
 ### lecture-python-programming.myst
 
 ```yaml
-# Standard setup (no ML libs)
+# Standard setup
 - uses: quantecon/actions/setup-environment@v1
   with:
     install-latex: 'true'

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,9 @@ Step-by-step guide for migrating lecture repositories
 ### [QUICK-REFERENCE.md](./QUICK-REFERENCE.md)
 Action inputs, outputs, and usage examples
 
+### [GPU-AMI-SETUP.md](./GPU-AMI-SETUP.md)
+Building RunsOn AMI for GPU lecture builds (driver requirements, ML library bundling)
+
 ### [FUTURE-DEVELOPMENT.md](./FUTURE-DEVELOPMENT.md)
 Planned enhancements: GPU support, build optimizations, monitoring
 

--- a/setup-environment/README.md
+++ b/setup-environment/README.md
@@ -14,7 +14,6 @@ Flexible, container-aware environment setup action for QuantEcon lectures. Auto-
 1. Caches Conda environment based on `environment.yml` hash
 2. Installs full Conda environment
 3. Optional LaTeX installation via apt-get
-4. Optional ML libraries (JAX/PyTorch)
 
 ## Key Benefits
 
@@ -93,15 +92,6 @@ dependencies:
     environment-name: 'quantecon'
 ```
 
-### With ML Libraries (GPU builds)
-
-```yaml
-- uses: quantecon/actions/setup-environment@v1
-  with:
-    install-latex: 'true'
-    install-ml-libs: 'true'
-```
-
 ## Inputs
 
 | Input | Description | Required | Default |
@@ -113,8 +103,6 @@ dependencies:
 | `cache-version` | Cache version for manual invalidation | No | `v1` |
 | `install-latex` | Install LaTeX packages (auto-disabled in container) | No | `false` |
 | `latex-requirements-file` | Path to latex-requirements.txt | No | `latex-requirements.txt` |
-| `install-ml-libs` | Install JAX/PyTorch with CUDA | No | `false` |
-| `ml-libs-version` | ML libraries version tag | No | `jax062-torch-nightly-cuda12` |
 
 ## Outputs
 
@@ -171,7 +159,6 @@ The container already includes: numpy, scipy, pandas, matplotlib, jupyter, jupyt
 |----------|------------------|
 | **Standard CPU lectures** | Container + `setup-environment` |
 | **GPU lectures (RunsOn AMI)** | AMI with marker file + `environment-update` |
-| **GPU lectures (no AMI)** | `setup-environment` with `install-ml-libs: true` |
 | **Local development** | Container or full `setup-environment` |
 | **Legacy workflows** | `setup-environment` with `install-latex: true` |
 
@@ -242,7 +229,6 @@ jobs:
 | Miniconda install | Skipped (pre-installed) | Installed |
 | Full conda env create | Skipped (pre-installed) | From `environment` |
 | LaTeX install | Skipped (pre-installed) | If `install-latex: true` |
-| ML libs install | Skipped (pre-installed) | If `install-ml-libs: true` |
 | Delta package update | If `environment-update` set | N/A |
 
 ### Advantage Over Containers

--- a/setup-environment/action.yml
+++ b/setup-environment/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup Environment'
-description: 'Flexible environment setup - auto-detects container or installs Conda, LaTeX, and ML libraries'
+description: 'Flexible environment setup - auto-detects container or installs Conda and LaTeX'
 author: 'QuantEcon'
 
 inputs:
@@ -31,14 +31,6 @@ inputs:
     description: 'Path to latex-requirements.txt file listing packages to install'
     required: false
     default: 'latex-requirements.txt'
-  install-ml-libs:
-    description: 'Whether to install JAX/PyTorch with CUDA support'
-    required: false
-    default: 'false'
-  ml-libs-version:
-    description: 'Version tag for ML libraries cache key'
-    required: false
-    default: 'jax062-torch-nightly-cuda12'
 
 outputs:
   container-mode:
@@ -145,33 +137,6 @@ runs:
         fi
 
     # ============================================================
-    # ML LIBRARIES: Same for both modes
-    # ============================================================
-    
-    - name: Cache pip packages (ML libs)
-      uses: actions/cache@v4
-      if: inputs.install-ml-libs == 'true'
-      id: pip-cache
-      with:
-        path: ~/.cache/pip
-        key: pip-${{ runner.os }}-${{ inputs.ml-libs-version }}-${{ hashFiles(inputs.environment) }}-${{ inputs.cache-version }}
-        restore-keys: |
-          pip-${{ runner.os }}-${{ inputs.ml-libs-version }}-
-          pip-${{ runner.os }}-
-
-    - name: Install JAX, PyTorch, NumPyro, Pyro
-      if: inputs.install-ml-libs == 'true'
-      shell: bash -l {0}
-      run: |
-        echo "Installing ML libraries with CUDA support..."
-        pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
-        pip install pyro-ppl
-        pip install --upgrade "jax[cuda12-local]==0.6.2"
-        pip install numpyro
-        echo "Testing JAX installation..."
-        python scripts/test-jax-install.py || echo "JAX test script not found or failed (non-fatal)"
-
-    # ============================================================
     # SUMMARY: Display environment info
     # ============================================================
         
@@ -212,9 +177,6 @@ runs:
           else
             echo "   LaTeX: Skipped"
           fi
-        fi
-        if [ "${{ inputs.install-ml-libs }}" == "true" ]; then
-          echo "   ML Libraries: Installed (JAX, PyTorch)"
         fi
         echo "::endgroup::"
         


### PR DESCRIPTION
## Summary

Remove the hardcoded ML libraries install (`install-ml-libs` and `ml-libs-version` inputs) from `setup-environment`.

## Rationale

ML/GPU libraries (JAX, PyTorch, numpyro) should be specified in each repo's `environment.yml` or `environment-update.yml` rather than being hardcoded in the action. Key reasons:

- **JAX bundles its own CUDA toolkit** — `pip install jax[cuda13]` includes everything needed; system-level CUDA installation is unnecessary as long as GPU drivers are on the AMI
- **Version drift** — The action had `jax[cuda12-local]==0.6.2` hardcoded while `lecture-python.myst` already uses `jax[cuda13]`. Letting repos own their versions avoids this mismatch
- **Simpler action** — Removes 2 inputs, 2 steps (pip cache + install), and summary references. The action now focuses on environment setup (Conda, LaTeX, container detection)

## Changes

| File | Change |
|------|--------|
| `setup-environment/action.yml` | Remove `install-ml-libs`, `ml-libs-version` inputs; remove pip cache step; remove ML install step; remove summary reference |
| `setup-environment/README.md` | Remove ML libs usage examples, input table rows, and "GPU lectures (no AMI)" scenario |
| `PLAN.md` | Update feature matrix, remove "Verify JAX CUDA 13" item (resolved), update checklist |
| `docs/MIGRATION-GUIDE.md` | Replace `install-ml-libs` examples with `environment-update` approach |
| `docs/QUICK-REFERENCE.md` | Remove ML libs customization section, update input reference and repo examples |
| `CHANGELOG.md` | Add `[Unreleased]` removal entry |

## Migration path for GPU repos

Instead of:
```yaml
- uses: quantecon/actions/setup-environment@v1
  with:
    install-ml-libs: 'true'
```

Repos specify ML packages in their `environment-update.yml`:
```yaml
name: quantecon
dependencies:
  - pip:
    - jax[cuda13]
    - numpyro
    - torch
```

And reference it:
```yaml
- uses: quantecon/actions/setup-environment@v1
  with:
    environment-update: 'environment-update.yml'
```
