### PR TITLE
Upgrade quantecon-book-theme to 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Containers**: Upgraded `quantecon-book-theme` from 0.10.1 to 0.18.0
 - **CI**: Temporarily disabled lecture-jax in container tests until JAX installation commands are added ([lecture-jax#284](https://github.com/QuantEcon/lecture-jax/issues/284))
 
 ## [0.6.0] - 2026-02-09

--- a/containers/quantecon-build/environment.yml
+++ b/containers/quantecon-build/environment.yml
@@ -56,7 +56,7 @@ dependencies:
   - pip:
     # Jupyter Book build tools
     - jupyter-book>=1.0.4post1,<2.0
-    - quantecon-book-theme>=0.10.1
+    - quantecon-book-theme>=0.18.0
     - sphinx-tojupyter>=0.4.0
     - sphinxext-rediraffe>=0.2.7
     - sphinx-exercise>=1.2.0

--- a/containers/quantecon/README.md
+++ b/containers/quantecon/README.md
@@ -113,7 +113,7 @@ conda list        # See all packages
 
 **Jupyter Book Build Tools:**
 - jupyter-book (1.0.4post1) - Document builder
-- quantecon-book-theme (0.10.1) - Custom theme
+- quantecon-book-theme (0.18.0) - Custom theme
 - Sphinx extensions (tojupyter, rediraffe, exercise, proof, youtube, togglebutton, reredirects)
 - quantecon-book-networks
 

--- a/containers/quantecon/environment.yml
+++ b/containers/quantecon/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - pip:
     # Jupyter Book build tools
     - jupyter-book==1.0.4post1
-    - quantecon-book-theme==0.10.1
+    - quantecon-book-theme==0.18.0
     - sphinx-tojupyter==0.4.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.2.0


### PR DESCRIPTION
## Summary

Upgrade `quantecon-book-theme` from `0.10.1` to `0.18.0` in both container environments.

## Changes

| File | Change |
|------|--------|
| `containers/quantecon/environment.yml` | `==0.10.1` → `==0.18.0` |
| `containers/quantecon-build/environment.yml` | `>=0.10.1` → `>=0.18.0` |
| `containers/quantecon/README.md` | Version reference updated |
| `CHANGELOG.md` | Added entry under `[Unreleased]` |

## Notes

- Containers will need to be rebuilt after merge to pick up the new theme version.
