### PR TITLE
Standardize action references on floating @v0 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Containers**: Upgraded `quantecon-book-theme` from 0.10.1 to 0.18.0
 - **CI**: Temporarily disabled lecture-jax in container tests until JAX installation commands are added ([lecture-jax#284](https://github.com/QuantEcon/lecture-jax/issues/284))
+- **Docs**: Standardised all template and documentation action references on the floating `@v0`
+  tag (was `@v1`, which never existed and broke any copied template). Documented the `@v0`
+  convention in `README.md` and added a step to move the floating `v0` tag on each release in
+  `CONTRIBUTING.md`.
 
 ## [0.6.0] - 2026-02-09
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,10 @@
 
 We use semantic versioning:
 
-| Tag | Purpose |
-|-----|---------|
+| Reference | Purpose |
+|-----------|---------|
 | `@v0` | Latest `0.x` release — floating tag, force-moved to each new release (recommended) |
-| `v0.6.0` | Specific release version (maximum reproducibility) |
+| `@v0.x.y` | A specific pinned release (maximum reproducibility) |
 | `@main` | Latest development (testing only) |
 
 During `0.x`, `@v0` is the floating reference. Because minor releases (`0.x.0`) may include

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,14 @@ We use semantic versioning:
 
 | Tag | Purpose |
 |-----|---------|
-| `v0.5.2` | Specific release version |
+| `@v0` | Latest `0.x` release — floating tag, force-moved to each new release (recommended) |
+| `v0.6.0` | Specific release version (maximum reproducibility) |
 | `@main` | Latest development (testing only) |
 
-After 1.0.0 release, we'll add floating major tags (`v1`, `v2`) for stable references.
+During `0.x`, `@v0` is the floating reference. Because minor releases (`0.x.0`) may include
+breaking changes, `@v0` can move across a breaking change — consumers needing strict stability
+should pin an exact `v0.x.y` tag. After the 1.0.0 release, we'll add floating major tags
+(`v1`, `v2`) for stable references.
 
 ### Creating a Release
 
@@ -44,13 +48,19 @@ After 1.0.0 release, we'll add floating major tags (`v1`, `v2`) for stable refer
    - Add release date
    - For breaking changes in 0.x, mark with ⚠️ **BREAKING**
 
-2. **Create and push tags:**
+2. **Create and push the version tag:**
    ```bash
    git tag -a v0.x.y -m "Release v0.x.y - Description"
    git push origin v0.x.y
    ```
 
-3. **Create GitHub Release** at https://github.com/QuantEcon/actions/releases/new
+3. **Move the floating `v0` tag to this release** so `@v0` consumers pick it up:
+   ```bash
+   git tag -f v0 v0.x.y
+   git push origin v0 --force
+   ```
+
+4. **Create GitHub Release** at https://github.com/QuantEcon/actions/releases/new
    - Copy changelog entry as release notes
    - Attach any relevant artifacts
 

--- a/README.md
+++ b/README.md
@@ -172,11 +172,16 @@ Use `build-jupyter-cache` and `restore-jupyter-cache` actions for execution cach
 
 ## Versioning
 
-We use semantic versioning with Git tags:
+We're in the `0.x` development phase (pre-1.0.0). Reference the actions with:
 
-- `@v1` - Latest stable v1.x.x release (recommended for production)
-- `@v1.0.0` - Specific version (maximum stability)
+- `@v0` - Latest `0.x` release (recommended; floating tag, moved to each new release)
+- `@v0.6.0` - Specific version (maximum reproducibility)
 - `@main` - Latest development (use for testing only)
+
+> ⚠️ During `0.x`, minor releases (`0.x.0`) may include breaking changes, so the floating
+> `@v0` tag can move across a breaking change. Pin to an exact `@v0.x.y` tag if you need
+> a guaranteed-stable reference. Floating major tags (`@v1`, `@v2`) will be introduced
+> after the 1.0.0 release.
 
 ## Documentation
 

--- a/build-jupyter-cache/README.md
+++ b/build-jupyter-cache/README.md
@@ -75,13 +75,13 @@ jobs:
       image: ghcr.io/quantecon/quantecon:latest
     steps:
       - uses: actions/checkout@v4
-      - uses: quantecon/actions/build-jupyter-cache@v1
+      - uses: quantecon/actions/build-jupyter-cache@v0
 ```
 
 ### All Builders with PDF
 
 ```yaml
-- uses: quantecon/actions/build-jupyter-cache@v1
+- uses: quantecon/actions/build-jupyter-cache@v0
   with:
     builders: 'jupyter,pdflatex,html'
 ```
@@ -89,7 +89,7 @@ jobs:
 ### Custom Issue Settings
 
 ```yaml
-- uses: quantecon/actions/build-jupyter-cache@v1
+- uses: quantecon/actions/build-jupyter-cache@v0
   with:
     builders: 'jupyter,html'
     create-issue-on-failure: true
@@ -100,7 +100,7 @@ jobs:
 ### Without Issue Creation
 
 ```yaml
-- uses: quantecon/actions/build-jupyter-cache@v1
+- uses: quantecon/actions/build-jupyter-cache@v0
   with:
     create-issue-on-failure: false
 ```
@@ -167,7 +167,7 @@ jobs:
       image: ghcr.io/quantecon/quantecon:latest
     steps:
       - uses: actions/checkout@v4
-      - uses: quantecon/actions/build-jupyter-cache@v1
+      - uses: quantecon/actions/build-jupyter-cache@v0
 ```
 
 Benefits:
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: quantecon/actions/build-jupyter-cache@v1
+      - uses: quantecon/actions/build-jupyter-cache@v0
         with:
           builders: 'jupyter,pdflatex,html'
 ```

--- a/build-lectures/README.md
+++ b/build-lectures/README.md
@@ -38,13 +38,13 @@ Builds QuantEcon lectures using Jupyter Book.
 ### HTML Build (Default)
 
 ```yaml
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
 ```
 
 ### PDF Build
 
 ```yaml
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     builder: 'pdflatex'
 ```
@@ -52,7 +52,7 @@ Builds QuantEcon lectures using Jupyter Book.
 ### Jupyter Notebook Build
 
 ```yaml
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     builder: 'jupyter'
 ```
@@ -60,7 +60,7 @@ Builds QuantEcon lectures using Jupyter Book.
 ### Custom Build Arguments
 
 ```yaml
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     builder: 'html'
     extra-args: '-W --keep-going -v'
@@ -69,7 +69,7 @@ Builds QuantEcon lectures using Jupyter Book.
 ### Using Build Output
 
 ```yaml
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   id: build
 
 - name: Upload artifacts
@@ -85,17 +85,17 @@ Build PDF and notebooks first, then HTML with asset assembly:
 
 ```yaml
 # Build PDF
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     builder: 'pdflatex'
 
 # Build notebooks  
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     builder: 'jupyter'
 
 # Build HTML and assemble all assets
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   id: build
   with:
     builder: 'html'
@@ -117,7 +117,7 @@ _build/html/
 ### Upload Reports on Build Failure
 
 ```yaml
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     upload-failure-reports: true
 ```
@@ -247,11 +247,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           install-latex: 'true'
       
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         id: build
       
       - uses: actions/upload-artifact@v4
@@ -268,8 +268,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: quantecon/actions/setup-environment@v1
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/setup-environment@v0
+      - uses: quantecon/actions/build-lectures@v0
         with:
           builder: 'html'
 
@@ -277,10 +277,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           install-latex: 'true'
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         with:
           builder: 'pdflatex'
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
       
       # 7-8 minutes: Setup environment + LaTeX
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           install-latex: 'true'
       
@@ -105,7 +105,7 @@ jobs:
       - run: jupyter-book build lectures/
       
       # Manual deployment
-      - uses: quantecon/actions/preview-netlify@v1
+      - uses: quantecon/actions/preview-netlify@v0
         with:
           # ... many configuration options
 ```
@@ -126,16 +126,16 @@ jobs:
         run: conda env update -f environment.yml
       
       # Restore cache from main branch (if available)
-      - uses: quantecon/actions/restore-jupyter-cache@v1
+      - uses: quantecon/actions/restore-jupyter-cache@v0
         with:
           cache-type: 'build'
       
       # Build (uses restored cache for incremental build)
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         id: build
       
       # Deploy preview (PR only)
-      - uses: quantecon/actions/preview-netlify@v1
+      - uses: quantecon/actions/preview-netlify@v0
         if: github.event_name == 'pull_request'
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -143,7 +143,7 @@ jobs:
           build-dir: ${{ steps.build.outputs.build-path }}
       
       # Deploy production (main branch)
-      - uses: quantecon/actions/publish-gh-pages@v1
+      - uses: quantecon/actions/publish-gh-pages@v0
         if: github.ref == 'refs/heads/main'
         with:
           build-dir: ${{ steps.build.outputs.build-path }}

--- a/docs/GPU-AMI-SETUP.md
+++ b/docs/GPU-AMI-SETUP.md
@@ -300,12 +300,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           environment-update: 'environment-update.yml'
         # Detects /etc/quantecon-container marker → skips Miniconda/LaTeX install
       
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
 ```
 
 **Repo's `environment-update.yml` specifies ML packages:**

--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -48,7 +48,7 @@ Before starting migration:
 
 ### After (Unified Action)
 ```yaml
-- uses: quantecon/actions/setup-environment@v1
+- uses: quantecon/actions/setup-environment@v0
   with:
     python-version: '3.13'
     environment: 'environment.yml'
@@ -139,7 +139,7 @@ jobs:
           fetch-depth: 0
       
       # Setup environment with caching
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           python-version: '3.13'
           environment: 'environment.yml'
@@ -147,11 +147,11 @@ jobs:
           install-latex: 'true'
       
       # Build lectures (with cache restore for fast incremental builds)
-      - uses: quantecon/actions/restore-jupyter-cache@v1
+      - uses: quantecon/actions/restore-jupyter-cache@v0
         with:
           cache-type: 'build'
       
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         id: build
         with:
           source-dir: 'lectures'
@@ -159,7 +159,7 @@ jobs:
           upload-failure-reports: true  # Upload reports if build fails
       
       # Deploy preview
-      - uses: quantecon/actions/preview-netlify@v1
+      - uses: quantecon/actions/preview-netlify@v0
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
@@ -233,7 +233,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: quantecon/actions/build-jupyter-cache@v1
+      - uses: quantecon/actions/build-jupyter-cache@v0
         with:
           builders: 'html'
           create-issue-on-failure: true
@@ -306,24 +306,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           install-latex: 'true'
       
       # Build PDF
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         with:
           builder: 'pdflatex'
           upload-failure-reports: true
       
       # Build notebooks
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         with:
           builder: 'jupyter'
           upload-failure-reports: true
       
       # Build HTML and assemble all assets
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         id: build
         with:
           builder: 'html'
@@ -332,7 +332,7 @@ jobs:
           upload-failure-reports: true
       
       # Deploy to GitHub Pages
-      - uses: quantecon/actions/publish-gh-pages@v1
+      - uses: quantecon/actions/publish-gh-pages@v0
         id: deploy
         with:
           build-dir: ${{ steps.build.outputs.build-path }}
@@ -353,7 +353,7 @@ jobs:
 # In ci.yml, cache.yml, publish.yml:
 # ML packages (JAX, PyTorch, numpyro) are specified in the repo's
 # environment.yml or environment-update.yml, not in the action.
-- uses: quantecon/actions/setup-environment@v1
+- uses: quantecon/actions/setup-environment@v0
   with:
     environment-update: 'environment-update.yml'
 
@@ -373,7 +373,7 @@ This workflow uses a different container and may need custom handling:
 
 # Option 1: Keep as-is for now
 # Option 2: Use only build-lectures action
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     build-html: 'true'
     cache-workflow: 'cache.yml'
@@ -475,15 +475,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           environment-update: 'environment-update.yml'
       
-      - uses: quantecon/actions/restore-jupyter-cache@v1
+      - uses: quantecon/actions/restore-jupyter-cache@v0
         with:
           cache-type: 'build'
       
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         id: build
 ```
 
@@ -504,15 +504,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           environment-update: 'environment-update.yml'  # Delta packages for container
       
-      - uses: quantecon/actions/restore-jupyter-cache@v1
+      - uses: quantecon/actions/restore-jupyter-cache@v0
         with:
           cache-type: 'build'
       
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         id: build
 ```
 
@@ -592,7 +592,7 @@ git push origin main
 ```yaml
 # In affected workflow file, comment out action and restore original:
 
-# - uses: quantecon/actions/setup-environment@v1
+# - uses: quantecon/actions/setup-environment@v0
 
 - name: Setup Anaconda
   uses: conda-incubator/setup-miniconda@v3

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -38,16 +38,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           environment-update: 'environment-update.yml'  # Optional - delta packages for container
         # Auto-detects container, installs only lecture-specific packages
-      - uses: quantecon/actions/restore-jupyter-cache@v1
+      - uses: quantecon/actions/restore-jupyter-cache@v0
         with:
           cache-type: 'build'
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         id: build
-      - uses: quantecon/actions/preview-netlify@v1
+      - uses: quantecon/actions/preview-netlify@v0
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
@@ -67,12 +67,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           install-latex: 'true'
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         id: build
-      - uses: quantecon/actions/preview-netlify@v1
+      - uses: quantecon/actions/preview-netlify@v0
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
@@ -104,12 +104,12 @@ jobs:
       url: ${{ steps.deploy.outputs.page-url }}
     steps:
       - uses: actions/checkout@v4
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           install-latex: 'true'
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         id: build
-      - uses: quantecon/actions/publish-gh-pages@v1
+      - uses: quantecon/actions/publish-gh-pages@v0
         id: deploy
         with:
           build-dir: ${{ steps.build.outputs.build-path }}
@@ -121,11 +121,11 @@ jobs:
 ### Build PDF
 
 ```yaml
-- uses: quantecon/actions/setup-environment@v1
+- uses: quantecon/actions/setup-environment@v0
   with:
     install-latex: 'true'
 
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     builder: 'pdflatex'
 ```
@@ -133,7 +133,7 @@ jobs:
 ### Build Jupyter Notebooks
 
 ```yaml
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     builder: 'jupyter'
 ```
@@ -143,11 +143,11 @@ jobs:
 Add `restore-jupyter-cache` before `build-lectures` to restore cached execution state:
 
 ```yaml
-- uses: quantecon/actions/restore-jupyter-cache@v1
+- uses: quantecon/actions/restore-jupyter-cache@v0
   with:
     cache-type: 'build'
 
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   id: build
 ```
 
@@ -156,7 +156,7 @@ Add `restore-jupyter-cache` before `build-lectures` to restore cached execution 
 ### Preview with Custom URL
 
 ```yaml
-- uses: quantecon/actions/preview-netlify@v1
+- uses: quantecon/actions/preview-netlify@v0
   with:
     netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
@@ -167,7 +167,7 @@ Add `restore-jupyter-cache` before `build-lectures` to restore cached execution 
 ### Force Cache Rebuild
 
 ```yaml
-- uses: quantecon/actions/setup-environment@v1
+- uses: quantecon/actions/setup-environment@v0
   with:
     cache-version: 'v2'  # Bump from v1
 ```
@@ -250,7 +250,7 @@ permissions:
 
 ```yaml
 - id: build
-  uses: quantecon/actions/build-lectures@v1
+  uses: quantecon/actions/build-lectures@v0
 
 # Access: ${{ steps.build.outputs.build-path }}
 ```
@@ -259,7 +259,7 @@ permissions:
 
 ```yaml
 - id: netlify
-  uses: quantecon/actions/preview-netlify@v1
+  uses: quantecon/actions/preview-netlify@v0
 
 # Access:
 # - ${{ steps.netlify.outputs.deploy-url }}
@@ -270,7 +270,7 @@ permissions:
 
 ```yaml
 - id: pages
-  uses: quantecon/actions/publish-gh-pages@v1
+  uses: quantecon/actions/publish-gh-pages@v0
 
 # Access: ${{ steps.pages.outputs.page-url }}
 ```
@@ -297,7 +297,7 @@ cache-version: 'v2'
 **Build too slow?**
 ```yaml
 # Use restore-jupyter-cache before build-lectures
-- uses: quantecon/actions/restore-jupyter-cache@v1
+- uses: quantecon/actions/restore-jupyter-cache@v0
   with:
     cache-type: 'build'
 ```
@@ -330,7 +330,7 @@ permissions:
 
 ```yaml
 # ML packages (JAX, PyTorch) specified in repo's environment.yml
-- uses: quantecon/actions/setup-environment@v1
+- uses: quantecon/actions/setup-environment@v0
   with:
     environment-update: 'environment-update.yml'
 ```
@@ -339,7 +339,7 @@ permissions:
 
 ```yaml
 # Standard setup
-- uses: quantecon/actions/setup-environment@v1
+- uses: quantecon/actions/setup-environment@v0
   with:
     install-latex: 'true'
 ```
@@ -348,14 +348,14 @@ permissions:
 
 ```yaml
 # Netlify only (no GH Pages)
-- uses: quantecon/actions/preview-netlify@v1
+- uses: quantecon/actions/preview-netlify@v0
 ```
 
 ### lecture-python-advanced.myst
 
 ```yaml
 # Same as programming (standard setup)
-- uses: quantecon/actions/setup-environment@v1
+- uses: quantecon/actions/setup-environment@v0
   with:
     install-latex: 'true'
 ```

--- a/preview-cloudflare/README.md
+++ b/preview-cloudflare/README.md
@@ -13,7 +13,7 @@ Deploys QuantEcon lecture builds to Cloudflare Pages for PR previews with smart 
 ## Usage
 
 ```yaml
-- uses: quantecon/actions/preview-cloudflare@v1
+- uses: quantecon/actions/preview-cloudflare@v0
   with:
     cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -90,7 +90,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Environment
-        uses: quantecon/actions/setup-environment@v1
+        uses: quantecon/actions/setup-environment@v0
         with:
           environment: environment.yml
 
@@ -98,7 +98,7 @@ jobs:
         run: jb build lectures --path-output ./
 
       - name: Deploy Preview
-        uses: quantecon/actions/preview-cloudflare@v1
+        uses: quantecon/actions/preview-cloudflare@v0
         with:
           cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/preview-netlify/README.md
+++ b/preview-netlify/README.md
@@ -13,7 +13,7 @@ Deploys QuantEcon lecture builds to Netlify for PR previews with smart comments 
 ## Usage
 
 ```yaml
-- uses: quantecon/actions/preview-netlify@v1
+- uses: quantecon/actions/preview-netlify@v0
   with:
     netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Environment
-        uses: quantecon/actions/setup-environment@v1
+        uses: quantecon/actions/setup-environment@v0
         with:
           environment: environment.yml
 
@@ -96,7 +96,7 @@ jobs:
         run: jb build lectures --path-output ./
 
       - name: Deploy Preview
-        uses: quantecon/actions/preview-netlify@v1
+        uses: quantecon/actions/preview-netlify@v0
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}

--- a/publish-gh-pages/README.md
+++ b/publish-gh-pages/README.md
@@ -46,7 +46,7 @@ This action uses GitHub's native Pages deployment (via artifacts) instead of pus
 ### Basic Deployment
 
 ```yaml
-- uses: quantecon/actions/publish-gh-pages@v1
+- uses: quantecon/actions/publish-gh-pages@v0
   with:
     build-dir: '_build/html'
 ```
@@ -54,7 +54,7 @@ This action uses GitHub's native Pages deployment (via artifacts) instead of pus
 ### With Custom Domain
 
 ```yaml
-- uses: quantecon/actions/publish-gh-pages@v1
+- uses: quantecon/actions/publish-gh-pages@v0
   with:
     build-dir: '_build/html'
     cname: 'python.quantecon.org'
@@ -63,7 +63,7 @@ This action uses GitHub's native Pages deployment (via artifacts) instead of pus
 ### Using Page URL
 
 ```yaml
-- uses: quantecon/actions/publish-gh-pages@v1
+- uses: quantecon/actions/publish-gh-pages@v0
   id: pages
   with:
     build-dir: '_build/html'
@@ -78,7 +78,7 @@ This action uses GitHub's native Pages deployment (via artifacts) instead of pus
 Create downloadable archives attached to GitHub releases:
 
 ```yaml
-- uses: quantecon/actions/publish-gh-pages@v1
+- uses: quantecon/actions/publish-gh-pages@v0
   with:
     build-dir: '_build/html'
     cname: 'python.quantecon.org'
@@ -214,14 +214,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           install-latex: 'true'
       
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
         id: build
       
-      - uses: quantecon/actions/publish-gh-pages@v1
+      - uses: quantecon/actions/publish-gh-pages@v0
         id: deploy
         with:
           build-dir: ${{ steps.build.outputs.build-path }}
@@ -236,7 +236,7 @@ jobs:
 Deploy only on main branch:
 
 ```yaml
-- uses: quantecon/actions/publish-gh-pages@v1
+- uses: quantecon/actions/publish-gh-pages@v0
   if: github.ref == 'refs/heads/main'
   with:
     build-dir: '_build/html'
@@ -268,7 +268,7 @@ If migrating from peaceiris/actions-gh-pages or similar:
        target-branch: 'gh-pages'
    
    # After
-   - uses: quantecon/actions/publish-gh-pages@v1
+   - uses: quantecon/actions/publish-gh-pages@v0
      with:
        build-dir: '_build/html'
    ```

--- a/restore-jupyter-cache/README.md
+++ b/restore-jupyter-cache/README.md
@@ -64,15 +64,15 @@ Restores only `.jupyter_cache` directory containing cached notebook execution ou
 ### Basic Usage (Build Cache)
 
 ```yaml
-- uses: quantecon/actions/restore-jupyter-cache@v1
+- uses: quantecon/actions/restore-jupyter-cache@v0
 
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
 ```
 
 ### Execution Cache Only
 
 ```yaml
-- uses: quantecon/actions/restore-jupyter-cache@v1
+- uses: quantecon/actions/restore-jupyter-cache@v0
   with:
     cache-type: 'execution'
 ```
@@ -81,18 +81,18 @@ Restores only `.jupyter_cache` directory containing cached notebook execution ou
 
 ```yaml
 # Restore once at start
-- uses: quantecon/actions/restore-jupyter-cache@v1
+- uses: quantecon/actions/restore-jupyter-cache@v0
 
 # All builds share restored state
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     builder: 'jupyter'
 
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     builder: 'pdflatex'
 
-- uses: quantecon/actions/build-lectures@v1
+- uses: quantecon/actions/build-lectures@v0
   with:
     builder: 'html'
     html-copy-pdf: true
@@ -102,7 +102,7 @@ Restores only `.jupyter_cache` directory containing cached notebook execution ou
 ### Require Cache (Fail if Missing)
 
 ```yaml
-- uses: quantecon/actions/restore-jupyter-cache@v1
+- uses: quantecon/actions/restore-jupyter-cache@v0
   with:
     fail-on-miss: true
 ```

--- a/setup-environment/README.md
+++ b/setup-environment/README.md
@@ -43,10 +43,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         # environment-update defaults to '' - uses pre-installed packages
       
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
 ```
 
 ### Container with No Extra Packages (Fastest)
@@ -57,7 +57,7 @@ If the container has all packages you need:
 container:
   image: ghcr.io/quantecon/quantecon-build:latest
 steps:
-  - uses: quantecon/actions/setup-environment@v1
+  - uses: quantecon/actions/setup-environment@v0
     # environment-update defaults to '' - uses pre-installed packages
 ```
 
@@ -67,7 +67,7 @@ If you need a few extra packages not in the container:
 
 ```yaml
 steps:
-  - uses: quantecon/actions/setup-environment@v1
+  - uses: quantecon/actions/setup-environment@v0
     with:
       environment-update: 'environment-update.yml'  # Delta packages only
 ```
@@ -83,7 +83,7 @@ dependencies:
 ### Standard Build (ubuntu-latest)
 
 ```yaml
-- uses: quantecon/actions/setup-environment@v1
+- uses: quantecon/actions/setup-environment@v0
   with:
     python-version: '3.13'
     environment: 'environment.yml'
@@ -214,12 +214,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: quantecon/actions/setup-environment@v1
+      - uses: quantecon/actions/setup-environment@v0
         with:
           environment-update: 'environment-update.yml'  # Delta packages only
         # Detects /etc/quantecon-container → skips full install
 
-      - uses: quantecon/actions/build-lectures@v1
+      - uses: quantecon/actions/build-lectures@v0
 ```
 
 ### What Container Mode Skips on AMI

--- a/templates/cache.yml
+++ b/templates/cache.yml
@@ -11,7 +11,7 @@
 #   - Manual dispatch — on-demand rebuild
 #   - Push to main (environment.yml changes) — update cache after env change
 #
-# Action versions: Pin to @v0 for stability. Check for latest at:
+# Action versions: @v0 = latest 0.x release (floating); pin @v0.x.y for reproducibility. Latest at:
 #   https://github.com/quantecon/actions/releases
 
 name: Build Cache

--- a/templates/cache.yml
+++ b/templates/cache.yml
@@ -11,7 +11,7 @@
 #   - Manual dispatch — on-demand rebuild
 #   - Push to main (environment.yml changes) — update cache after env change
 #
-# Action versions: Pin to @v1 for stability. Check for latest at:
+# Action versions: Pin to @v0 for stability. Check for latest at:
 #   https://github.com/quantecon/actions/releases
 
 name: Build Cache
@@ -59,7 +59,7 @@ jobs:
       # Build all requested formats and save cache.
       # Only saves if ALL builds succeed — preserves existing cache on failure.
       - name: Build and cache
-        uses: quantecon/actions/build-jupyter-cache@v1
+        uses: quantecon/actions/build-jupyter-cache@v0
         with:
           # ─── Builders ──────────────────────────────────────────
           # Comma-separated list: html, jupyter, pdflatex

--- a/templates/ci.yml
+++ b/templates/ci.yml
@@ -10,7 +10,7 @@
 #   2. Netlify site created for PR previews
 #   3. Repository secrets: NETLIFY_AUTH_TOKEN, NETLIFY_SITE_ID
 #
-# Action versions: Pin to @v0 for stability. Check for latest at:
+# Action versions: @v0 = latest 0.x release (floating); pin @v0.x.y for reproducibility. Latest at:
 #   https://github.com/quantecon/actions/releases
 
 name: CI

--- a/templates/ci.yml
+++ b/templates/ci.yml
@@ -10,7 +10,7 @@
 #   2. Netlify site created for PR previews
 #   3. Repository secrets: NETLIFY_AUTH_TOKEN, NETLIFY_SITE_ID
 #
-# Action versions: Pin to @v1 for stability. Check for latest at:
+# Action versions: Pin to @v0 for stability. Check for latest at:
 #   https://github.com/quantecon/actions/releases
 
 name: CI
@@ -48,7 +48,7 @@ jobs:
 
       # ─── Environment Setup ───────────────────────────────────────
       - name: Setup environment
-        uses: quantecon/actions/setup-environment@v1
+        uses: quantecon/actions/setup-environment@v0
         # Container mode auto-detected — no setup needed unless you
         # have extra packages beyond the container's base environment.
         # with:
@@ -67,7 +67,7 @@ jobs:
       # This gives Jupyter Book pre-executed notebooks so the PR
       # build only re-runs changed content (seconds instead of hours).
       - name: Restore build cache
-        uses: quantecon/actions/restore-jupyter-cache@v1
+        uses: quantecon/actions/restore-jupyter-cache@v0
         with:
           cache-type: 'build'          # Full _build directory (default)
           # save-cache: 'true'         # Save updated cache scoped to this PR branch
@@ -75,7 +75,7 @@ jobs:
 
       # ─── Build ───────────────────────────────────────────────────
       - name: Build lectures (HTML)
-        uses: quantecon/actions/build-lectures@v1
+        uses: quantecon/actions/build-lectures@v0
         with:
           builder: 'html'
           source-dir: 'lectures'
@@ -88,7 +88,7 @@ jobs:
       # Deploys the built site to Netlify and posts a comment on the
       # PR with the preview URL and links to changed lecture pages.
       - name: Deploy PR preview
-        uses: quantecon/actions/preview-netlify@v1
+        uses: quantecon/actions/preview-netlify@v0
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
@@ -100,7 +100,7 @@ jobs:
       # Secrets needed: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID
       #
       # - name: Deploy PR preview
-      #   uses: quantecon/actions/preview-cloudflare@v1
+      #   uses: quantecon/actions/preview-cloudflare@v0
       #   with:
       #     cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       #     cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/templates/publish.yml
+++ b/templates/publish.yml
@@ -11,7 +11,7 @@
 #   2. GitHub Pages enabled: Settings → Pages → Source → "GitHub Actions"
 #   3. (Optional) Custom domain configured in Settings → Pages → Custom domain
 #
-# Action versions: Pin to @v0 for stability. Check for latest at:
+# Action versions: @v0 = latest 0.x release (floating); pin @v0.x.y for reproducibility. Latest at:
 #   https://github.com/quantecon/actions/releases
 
 name: Publish

--- a/templates/publish.yml
+++ b/templates/publish.yml
@@ -11,7 +11,7 @@
 #   2. GitHub Pages enabled: Settings → Pages → Source → "GitHub Actions"
 #   3. (Optional) Custom domain configured in Settings → Pages → Custom domain
 #
-# Action versions: Pin to @v1 for stability. Check for latest at:
+# Action versions: Pin to @v0 for stability. Check for latest at:
 #   https://github.com/quantecon/actions/releases
 
 name: Publish
@@ -55,7 +55,7 @@ jobs:
 
       # ─── Environment Setup ───────────────────────────────────────
       - name: Setup environment
-        uses: quantecon/actions/setup-environment@v1
+        uses: quantecon/actions/setup-environment@v0
         # with:
         #   environment-update: 'environment.yml'   # Delta packages for container
         #   install-latex: 'true'                    # Required for pdflatex builds
@@ -69,7 +69,7 @@ jobs:
 
       # ─── Cache Restore ───────────────────────────────────────────
       - name: Restore build cache
-        uses: quantecon/actions/restore-jupyter-cache@v1
+        uses: quantecon/actions/restore-jupyter-cache@v0
 
       # ─── Build ───────────────────────────────────────────────────
       # Build HTML (and optionally other formats). The cache gives
@@ -78,20 +78,20 @@ jobs:
 
       # Optional: Build notebooks for download links
       # - name: Build notebooks
-      #   uses: quantecon/actions/build-lectures@v1
+      #   uses: quantecon/actions/build-lectures@v0
       #   with:
       #     builder: 'jupyter'
       #     source-dir: 'lectures'
 
       # Optional: Build PDF for download link
       # - name: Build PDF
-      #   uses: quantecon/actions/build-lectures@v1
+      #   uses: quantecon/actions/build-lectures@v0
       #   with:
       #     builder: 'pdflatex'
       #     source-dir: 'lectures'
 
       - name: Build HTML
-        uses: quantecon/actions/build-lectures@v1
+        uses: quantecon/actions/build-lectures@v0
         with:
           builder: 'html'
           source-dir: 'lectures'
@@ -103,7 +103,7 @@ jobs:
       # ─── Publish ─────────────────────────────────────────────────
       - name: Publish to GitHub Pages
         id: publish
-        uses: quantecon/actions/publish-gh-pages@v1
+        uses: quantecon/actions/publish-gh-pages@v0
         with:
           build-dir: '_build/html'
           # cname: 'lectures.example.org'   # Custom domain (adds CNAME file)


### PR DESCRIPTION
## Summary

Every template, doc, and action README referenced `quantecon/actions/...@v1` (**116 occurrences**), but **no `v1` tag exists** — so copying any template produced a "tag not found" error. We're pre-1.0.0, and `CONTRIBUTING.md` reserves floating major tags (`v1`, `v2`) for *after* the 1.0.0 release, so `@v0` is the correct floating reference during the `0.x` phase.

This fixes review findings **C1** (the `@v1`/no-tag mismatch) and **N1** (the stale `v0` tag).

## Changes

- **Switch all `quantecon/actions/...@v1` → `@v0`** across templates, docs, and action READMEs. The unrelated `action-download-artifact@v12` reference in `PLAN.md` was deliberately left untouched.
- **`README.md` Versioning section:** drop the false *"@v1 - Latest stable v1.x.x release"* claim (it contradicted `CONTRIBUTING.md` and reality); document `@v0` (floating) / `@v0.6.0` (pinned) / `@main`, with a warning that `@v0` can move across a `0.x` breaking change.
- **`CONTRIBUTING.md`:** add `@v0` to the tag table and add a release step that force-moves the floating `v0` tag to each new release.
- **`CHANGELOG.md`:** note under `[Unreleased]`.
- **Tidy-up:** removed the scratch `REVIEW-*.md` technical-review notes from the repo.

## ⚠️ Required follow-up (maintainer action — not in this PR)

The `v0` git tag is **currently stale**: it points at `6566f90` (v0.5.2-era, 2026-02-06), *behind* `v0.6.0`. A PR diff can't move a tag, so after merging, the floating tag must be force-moved for `@v0` to resolve to current code:

```bash
git tag -f v0 v0.6.0      # or the latest release tag
git push origin v0 --force
```

This is an outward-facing tag operation that downstream lecture repos consume, so it's intentionally left for a maintainer to run (now documented in `CONTRIBUTING.md`).

## Verification

- `git grep 'quantecon/actions/...@v1'` → no matches remain.
- `action-download-artifact@v12` in `PLAN.md` → unchanged.
- 117 `@v0` action references across the tree, internally consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)