### PR TITLE
Clean up cache actions: honest restore key + caching docs (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   honest (behaviour unchanged — restore still falls through to prefix matching). (#34, H4)
 
 ### Changed
-- **restore-jupyter-cache**: Documented the optional `save-cache` input (PR-scoped saving) and the
-  `path` constraint (must match `build-jupyter-cache`'s `_build`); the README no longer claims the
-  action is strictly read-only. (#34, H5/L21)
+- **restore-jupyter-cache**: Documented the optional `save-cache` input (PR-scoped saving) and
+  clarified the `path` constraint (must match where `build-lectures` reads, `_build`) across the
+  README and `docs/QUICK-REFERENCE.md`; the docs no longer claim the action is strictly read-only.
+  (#34, H5/L21)
 - **Docs**: Documented that the build-cache key is intentionally environment-only (warm-start
   baseline; freshness handled by jupyter-cache + Sphinx incremental + the weekly cold rebuild) in
   the cache action READMEs and `docs/ARCHITECTURE.md`. (#34, H6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **restore-jupyter-cache**: Read-only restore no longer uses a fake `-00000000` primary key that
+  could never match; it now uses the content/env prefix directly, so the logged "Requested Key" is
+  honest (behaviour unchanged — restore still falls through to prefix matching). (#34, H4)
+
+### Changed
+- **restore-jupyter-cache**: Documented the optional `save-cache` input (PR-scoped saving) and the
+  `path` constraint (must match `build-jupyter-cache`'s `_build`); the README no longer claims the
+  action is strictly read-only. (#34, H5/L21)
+- **Docs**: Documented that the build-cache key is intentionally environment-only (warm-start
+  baseline; freshness handled by jupyter-cache + Sphinx incremental + the weekly cold rebuild) in
+  the cache action READMEs and `docs/ARCHITECTURE.md`. (#34, H6)
+
 ## [0.7.0] - 2026-06-16
 
 ### Added

--- a/build-jupyter-cache/README.md
+++ b/build-jupyter-cache/README.md
@@ -44,6 +44,12 @@ This ensures PRs always have a working cache to restore, even when the weekly bu
 
 Each successful build creates a new cache entry. Old caches expire automatically after 7 days of no access (GitHub's default).
 
+> **Why no lecture-content hash?** The key is intentionally environment-only. `_build` is a
+> warm-start baseline; freshness is handled by jupyter-cache (per-notebook, content-addressed),
+> Sphinx incremental rebuilds, and this weekly cold rebuild. Adding a content hash would miss the
+> cache on nearly every PR and force a cold rebuild for no correctness gain. See the *Cache Key
+> Strategy* section of [restore-jupyter-cache](../restore-jupyter-cache/) for the full rationale.
+
 **Restore key pattern** (used by `restore-jupyter-cache`):
 ```yaml
 restore-keys: |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -219,6 +219,11 @@ jobs:
 - Build cache eliminates unnecessary rebuilds (~3-8 min)
 - Combined effect: 10x faster on cached builds
 
+**Why the build cache is keyed on the environment, not lecture content:**
+- `_build` is a stable warm-start baseline from `main`; a content hash would miss the cache on every PR (each edits some `.md`) and force a cold, full re-execution.
+- Freshness is handled elsewhere: jupyter-cache re-executes only changed notebooks (content-addressed per notebook), Sphinx rebuilds incrementally, and the weekly cold rebuild clears any drift.
+- Trade-off: Sphinx incremental doesn't delete output for removed sources, so deleted/renamed lectures can leave *orphaned* pages — but they're unreachable in navigation (absent from `_toc.yml`) and cleared by the weekly rebuild.
+
 ---
 
 ## Performance Targets

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -9,7 +9,7 @@ A cheat sheet for using QuantEcon composite actions in your workflows.
 | `setup-environment` | Conda + Python + LaTeX | ~5-6 min (cached) |
 | `build-lectures` | Jupyter Book builds | Varies (cached execution) |
 | `build-jupyter-cache` | Weekly cache generation (main branch) | Enables 80% faster CI |
-| `restore-jupyter-cache` | Read-only cache restore (PRs) | ~14 min (avoids full rebuild) |
+| `restore-jupyter-cache` | Cache restore for PRs (read-only by default; optional `save-cache`) | ~14 min (avoids full rebuild) |
 | `preview-netlify` | PR preview deployment (Netlify) | ~1 min |
 | `preview-cloudflare` | PR preview deployment (Cloudflare) | ~1 min |
 | `publish-gh-pages` | GitHub Pages deployment | ~30 sec |
@@ -140,7 +140,7 @@ jobs:
 
 ### Fast PR Builds (with Execution Cache)
 
-Add `restore-jupyter-cache` before `build-lectures` to restore cached execution state:
+Add `restore-jupyter-cache` before `build-lectures` to restore cached execution state. The restore is **read-only** by default; set `save-cache: true` to also save an updated cache at job end, scoped to the PR branch (speeds up later runs on the same PR):
 
 ```yaml
 - uses: quantecon/actions/restore-jupyter-cache@v0

--- a/restore-jupyter-cache/README.md
+++ b/restore-jupyter-cache/README.md
@@ -24,7 +24,7 @@ read-only behaviour above.
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `cache-type` | `build` (full `_build`) or `execution` (`.jupyter_cache` only) | No | `build` |
-| `path` | Path to restore cache to. Must match where `build-jupyter-cache` saves (`_build`) — overriding it restores to a location the saved cache won't match | No | `_build` |
+| `path` | Directory to restore the cache into. Must match where `build-lectures` reads (`_build`) — pointing it elsewhere restores the cached content to a different directory, so the build steps won't see the restored state | No | `_build` |
 | `source-dir` | Source directory for lectures (used for content hash in execution cache) | No | `lectures` |
 | `environment` | Path to environment file (used for cache key hash) | No | `environment.yml` |
 | `environment-update` | Path to delta environment file for container builds (used for cache key hash) | No | `''` |

--- a/restore-jupyter-cache/README.md
+++ b/restore-jupyter-cache/README.md
@@ -4,25 +4,33 @@ Restores Jupyter Book build cache from GitHub Actions cache. Designed for PR wor
 
 ## Design Philosophy
 
-This action is **read-only** - it only restores cache, never saves. This ensures:
+By default this action is **read-only** - it restores cache but never saves. This ensures:
 
-- **Single source of truth**: Cache is always from main branch
+- **Single source of truth**: Cache comes from the main-branch `build-jupyter-cache` build
 - **No conflicts**: Multiple PRs don't overwrite each other's cache
 - **Predictable state**: You always know where cache came from
 
-For cache generation, use the `build-jupyter-cache` action in your cache.yml workflow.
+For cache generation on main, use the `build-jupyter-cache` action in your cache.yml workflow.
+
+### Optional PR-scoped saving (`save-cache`)
+
+Set `save-cache: true` to also **save** an updated cache at the end of the job. GitHub Actions
+scopes caches by ref, so the saved cache is visible only to subsequent runs on the same PR
+branch — it cannot affect other PRs or `main`. Leave it `false` (the default) to keep the strict
+read-only behaviour above.
 
 ## Inputs
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `cache-type` | `build` (full `_build`) or `execution` (`.jupyter_cache` only) | No | `build` |
-| `path` | Path to restore cache to | No | `_build` |
+| `path` | Path to restore cache to. Must match where `build-jupyter-cache` saves (`_build`) — overriding it restores to a location the saved cache won't match | No | `_build` |
 | `source-dir` | Source directory for lectures (used for content hash in execution cache) | No | `lectures` |
 | `environment` | Path to environment file (used for cache key hash) | No | `environment.yml` |
 | `environment-update` | Path to delta environment file for container builds (used for cache key hash) | No | `''` |
 | `key` | Custom cache key (auto-generated if not specified) | No | Auto |
 | `fail-on-miss` | Fail workflow if no cache found | No | `false` |
+| `save-cache` | Also save an updated cache at job end, scoped to the PR branch (see Design Philosophy) | No | `false` |
 
 ## Outputs
 
@@ -36,14 +44,31 @@ For cache generation, use the `build-jupyter-cache` action in your cache.yml wor
 The action uses **prefix matching** to find the most recently saved cache:
 
 **Build cache** (default):
-- Saves as: `build-{env-hash}-{run-id}`
-- Restores using prefix: `build-{env-hash}-` → finds most recent
+- Saves as: `build-{env-hash}-{update-hash}-{run-id}`
+- Restores using prefix: `build-{env-hash}-{update-hash}-` → finds most recent
 
 **Execution cache**:
 - Saves as: `jupyter-cache-{content-hash}-{run-id}`  
 - Restores using prefix: `jupyter-cache-{content-hash}-` → finds most recent
 
 This ensures PRs always get the latest successful cache without conflicts.
+
+### Why the build-cache key is keyed on the environment, not lecture content
+
+The build-cache key intentionally hashes only the environment, **not** `lectures/**/*.md`. The
+`_build` cache is a stable **warm-start baseline** from `main`, and freshness is handled
+downstream — so a content hash would only hurt:
+
+- **jupyter-cache** (inside `_build/.jupyter_cache`) is content-addressed per notebook — it
+  re-executes only notebooks whose code changed, regardless of the cache key.
+- **Sphinx** rebuilds incrementally, re-rendering only the pages that changed.
+- The weekly cold `build-jupyter-cache` run rebuilds `_build` from scratch, clearing any drift.
+
+Hashing lecture content into the key would miss the cache on essentially every PR (each PR edits
+some `.md`) and force a cold, full re-execution — defeating the warm-start for no correctness gain.
+The one side effect of incremental builds — Sphinx not deleting output for removed/renamed sources
+— leaves only **orphaned** pages (absent from `_toc.yml`, unreachable in navigation), which the
+weekly rebuild clears.
 
 ## Cache Types
 

--- a/restore-jupyter-cache/action.yml
+++ b/restore-jupyter-cache/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: false
     default: 'build'
   path:
-    description: 'Path to restore cache to. Must match where build-jupyter-cache saves (_build); overriding it restores to a location the saved cache will not match.'
+    description: 'Directory to restore the cache into. Must match where build-lectures reads/writes (_build); pointing it elsewhere restores the cached _build to a directory the build steps will not use.'
     required: false
     default: '_build'
   source-dir:

--- a/restore-jupyter-cache/action.yml
+++ b/restore-jupyter-cache/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: false
     default: 'build'
   path:
-    description: 'Path to restore cache to'
+    description: 'Path to restore cache to. Must match where build-jupyter-cache saves (_build); overriding it restores to a location the saved cache will not match.'
     required: false
     default: '_build'
   source-dir:
@@ -61,7 +61,11 @@ runs:
           if [ "${{ inputs.save-cache }}" = "true" ]; then
             KEY="jupyter-cache-${{ hashFiles(format('{0}/**/*.md', inputs.source-dir)) }}-${{ github.run_id }}"
           else
-            KEY="jupyter-cache-${{ hashFiles(format('{0}/**/*.md', inputs.source-dir)) }}-00000000"
+            # Read-only restore: use the content prefix as the key. Saved keys
+            # carry a -{run_id} suffix, so this never exact-matches and the
+            # restore falls through to restore-keys prefix matching — same
+            # result, but the "Requested Key" report is honest.
+            KEY="jupyter-cache-${{ hashFiles(format('{0}/**/*.md', inputs.source-dir)) }}-"
           fi
           echo "key=$KEY" >> $GITHUB_OUTPUT
           echo "restore-keys<<EOF" >> $GITHUB_OUTPUT
@@ -76,7 +80,8 @@ runs:
           if [ "${{ inputs.save-cache }}" = "true" ]; then
             KEY="build-${ENV_HASH}-${UPDATE_HASH}-${{ github.run_id }}"
           else
-            KEY="build-${ENV_HASH}-${UPDATE_HASH}-00000000"
+            # Read-only restore: use the content prefix as the key (see note above).
+            KEY="build-${ENV_HASH}-${UPDATE_HASH}-"
           fi
           echo "key=$KEY" >> $GITHUB_OUTPUT
           echo "restore-keys<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Addresses all four items in #34 — correctness + documentation cleanup in the cache actions. No behavioural change to caching; one dead code path removed and the caching design documented.

## Changes

### H4 — honest restore key (code)
`restore-jupyter-cache` read-only mode set the primary key to `…-00000000`, which can **never** match a saved key (the saver always suffixes with `${github.run_id}`). It silently fell through to `restore-keys` prefix matching. Now it uses the content/env **prefix** as the key directly:
- exec: `jupyter-cache-{hash}-`
- build: `build-{env}-{update}-`

Same restore result (prefix match), but the logged **"Requested Key"** is now truthful and the dead exact-match path is gone.

### H5 — README no longer claims strictly read-only (docs)
Documented the optional **`save-cache`** input (added in 0.5.2) in the Design Philosophy section and the inputs table — PR-scoped saving that GitHub Actions confines to the PR branch.

### L21 — `path` constraint documented (docs)
`path` must match where `build-jupyter-cache` saves (`_build`). Documented the constraint in the input `description` and the README table rather than leaving a knob that silently restores to the wrong location. (No caller passes `path:` today; removing it outright would be a cleaner but breaking follow-up.)

### H6 — build-cache key design documented (docs)
Per the decision recorded in #34, documented that the build-cache key is **intentionally environment-only**: `_build` is a warm-start baseline, and freshness is handled by jupyter-cache (per-notebook, content-addressed), Sphinx incremental rebuilds, and the weekly cold rebuild. A content hash would miss on nearly every PR and force a cold rebuild for no correctness gain. Added to both cache action READMEs and the caching section of `docs/ARCHITECTURE.md`.

## Verification
- `restore-jupyter-cache/action.yml` validated as YAML; no `-00000000` remains.
- Restore behaviour is unchanged (prefix matching was already the only working path).

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)