### PR TITLE
Container tests: check out the built SHA; document org scope (#37)

### DIFF
--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -1,5 +1,11 @@
 name: Test Container
 
+# Container images are pulled from the `quantecon` GHCR org by design — these
+# workflows validate QuantEcon's published containers. A fork building its own
+# images would need to change the org; github.repository_owner isn't used
+# directly because GHCR image paths must be lowercase while that expression
+# preserves the org's casing (e.g. "QuantEcon").
+
 on:
   workflow_dispatch:
   workflow_run:
@@ -15,6 +21,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Test files must match the commit that built the image. For
+          # workflow_run events checkout defaults to the default branch, not the
+          # triggering commit; fall back to github.sha for workflow_dispatch.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -56,6 +67,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Test files must match the commit that built the image. For
+          # workflow_run events checkout defaults to the default branch, not the
+          # triggering commit; fall back to github.sha for workflow_dispatch.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/test-containers-lectures.yml
+++ b/.github/workflows/test-containers-lectures.yml
@@ -7,6 +7,12 @@ name: Test Container Builds
 # Concurrency groups ensure the same repo never builds on two containers
 # simultaneously, avoiding network contention from concurrent dataset
 # downloads. Different repos can run in parallel.
+#
+# Scope: container images come from the `quantecon` GHCR org and the matrix
+# targets QuantEcon's public lecture repos — these tests are QuantEcon-specific
+# by design. github.repository_owner can't be used for the job-level container
+# image because GHCR requires a lowercase path while the expression preserves
+# the org's casing, so a fork would need to set the org explicitly.
 
 on:
   workflow_run:
@@ -55,6 +61,10 @@ jobs:
       - name: Checkout actions repository
         uses: actions/checkout@v4
         with:
+          # Use the composite actions from the commit that built the container
+          # under test. workflow_run checks out the default branch by default;
+          # fall back to github.sha for manual workflow_dispatch runs.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           path: actions-repo
 
       - name: Checkout lecture repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **restore-jupyter-cache**: Read-only restore no longer uses a fake `-00000000` primary key that
   could never match; it now uses the content/env prefix directly, so the logged "Requested Key" is
   honest (behaviour unchanged — restore still falls through to prefix matching). (#34, H4)
+- **CI**: Container test workflows (`test-container.yml`, `test-containers-lectures.yml`) now check
+  out the commit that built the image (`workflow_run.head_sha`, falling back to `github.sha`)
+  instead of the default branch, so tests run against the matching commit. (#37, M11/M12)
 
 ### Changed
 - **restore-jupyter-cache**: Documented the optional `save-cache` input (PR-scoped saving) and


### PR DESCRIPTION
Addresses #37 (M11/M12/M13) — the container test workflows ran against the wrong commit on `workflow_run`, plus a note on the hardcoded org.

## M11/M12 — check out the commit that built the image (the real fix)

Both test workflows trigger on `workflow_run` after **Build QuantEcon Containers**. For `workflow_run` events `actions/checkout` defaults to the **default branch**, not the SHA that triggered the build — so the test files / composite actions could be from a *different commit* than the one that produced the image under test.

Pinned the checkout to:
```yaml
ref: ${{ github.event.workflow_run.head_sha || github.sha }}
```
- `workflow_run.head_sha` for the triggered runs;
- falls back to `github.sha` for manual `workflow_dispatch`.

Applied to:
- **`test-container.yml`** — both job checkouts (full + lean).
- **`test-containers-lectures.yml`** — the **actions-repo** checkout only. The **lecture-repo** checkout deliberately keeps its default (it tracks lecture content, which isn't tied to the container build commit).

## M13 — hardcoded `quantecon` org → documented (not parameterised)

I resolved this via the issue's "document it" option rather than substituting `github.repository_owner`, because that substitution would actually **break**: GHCR image paths must be lowercase, but `github.repository_owner` preserves the org's casing (`QuantEcon`), and it can't be lowercased inside a job-level `container.image`. The workflows also target QuantEcon's public lecture repos in the matrix, so they're QuantEcon-specific by design. Added a header comment to each workflow explaining this (and what a fork would change).

## Verification
- Both workflows validated as YAML.
- `head_sha` ref present in both; the lecture-repo checkout confirmed unchanged.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)