### PR TITLE
Trim verbose org comments in container test workflows

### DIFF
--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -1,10 +1,7 @@
 name: Test Container
 
-# Container images are pulled from the `quantecon` GHCR org by design — these
-# workflows validate QuantEcon's published containers. A fork building its own
-# images would need to change the org; github.repository_owner isn't used
-# directly because GHCR image paths must be lowercase while that expression
-# preserves the org's casing (e.g. "QuantEcon").
+# The `quantecon` GHCR org is intentionally hardcoded (GHCR image paths must be
+# lowercase, so github.repository_owner — which preserves casing — can't be substituted here).
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-containers-lectures.yml
+++ b/.github/workflows/test-containers-lectures.yml
@@ -8,11 +8,8 @@ name: Test Container Builds
 # simultaneously, avoiding network contention from concurrent dataset
 # downloads. Different repos can run in parallel.
 #
-# Scope: container images come from the `quantecon` GHCR org and the matrix
-# targets QuantEcon's public lecture repos — these tests are QuantEcon-specific
-# by design. github.repository_owner can't be used for the job-level container
-# image because GHCR requires a lowercase path while the expression preserves
-# the org's casing, so a fork would need to set the org explicitly.
+# The `quantecon` GHCR org is intentionally hardcoded (GHCR image paths must be
+# lowercase, so github.repository_owner — which preserves casing — can't be substituted here).
 
 on:
   workflow_run:


### PR DESCRIPTION
Follow-up to #42 / #37.

The M13 note I added explained fork behavior at length. Forks aren't a concern for these QuantEcon-specific workflows, so this reduces each header comment to a single-line guard that keeps the one genuinely useful bit: **don't substitute `github.repository_owner` for the hardcoded `quantecon` org** — GHCR image paths must be lowercase, and that expression preserves the org's casing.

Comment-only change in `test-container.yml` and `test-containers-lectures.yml`; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)