### PR TITLE
build-jupyter-cache/publish: pin siblings, scope artifact, harden release (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI**: Container test workflows (`test-container.yml`, `test-containers-lectures.yml`) now check
   out the commit that built the image (`workflow_run.head_sha`, falling back to `github.sha`)
   instead of the default branch, so tests run against the matching commit. (#37, M11/M12)
+- **build-jupyter-cache**: Internal sibling action calls are pinned from `@main` to `@v0`, so a
+  pinned `build-jupyter-cache` no longer transitively executes unreleased `main` code. (Relative
+  `./` paths can't be used — in a composite action they resolve against the consumer's workspace,
+  not this repo.) (#38, H8)
+- **publish-gh-pages**: Release tarball is written to `$RUNNER_TEMP` (outside `build-dir`) so the
+  archive can't recurse into itself (#38, M15); `create-release-assets` now skips off-tag and fails
+  fast when `github-token` is missing, instead of erroring mid-upload (#38, M16).
 
 ### Changed
 - **restore-jupyter-cache**: Documented the optional `save-cache` input (PR-scoped saving) and
@@ -23,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docs**: Documented that the build-cache key is intentionally environment-only (warm-start
   baseline; freshness handled by jupyter-cache + Sphinx incremental + the weekly cold rebuild) in
   the cache action READMEs and `docs/ARCHITECTURE.md`. (#34, H6)
+- **build-jupyter-cache**: The `_build` artifact is now uploaded only when a build fails (for
+  debugging), instead of duplicating the cached `_build` into a 30-day artifact on every successful
+  run. (#38, M14)
 
 ## [0.7.0] - 2026-06-16
 

--- a/build-jupyter-cache/action.yml
+++ b/build-jupyter-cache/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: 'lectures'
   upload-artifact:
-    description: 'Upload _build directory as artifact for inspection'
+    description: 'Upload the _build directory as an artifact when a build fails (for debugging; on success the cache already holds it). Set false to suppress even that.'
     required: false
     default: 'true'
   artifact-retention-days:
@@ -129,7 +129,7 @@ runs:
     
     - name: Setup environment
       id: setup-env
-      uses: quantecon/actions/setup-environment@main
+      uses: quantecon/actions/setup-environment@v0
       with:
         environment: ${{ inputs.environment }}
         environment-update: ${{ inputs.environment-update }}
@@ -144,7 +144,7 @@ runs:
       id: build-jupyter
       if: steps.parse-builders.outputs.run-jupyter == 'true'
       continue-on-error: true
-      uses: quantecon/actions/build-lectures@main
+      uses: quantecon/actions/build-lectures@v0
       with:
         builder: 'jupyter'
         source-dir: ${{ inputs.source-dir }}
@@ -153,7 +153,7 @@ runs:
       id: build-pdflatex
       if: steps.parse-builders.outputs.run-pdflatex == 'true'
       continue-on-error: true
-      uses: quantecon/actions/build-lectures@main
+      uses: quantecon/actions/build-lectures@v0
       with:
         builder: 'pdflatex'
         source-dir: ${{ inputs.source-dir }}
@@ -162,7 +162,7 @@ runs:
       id: build-html
       if: steps.parse-builders.outputs.run-html == 'true'
       continue-on-error: true
-      uses: quantecon/actions/build-lectures@main
+      uses: quantecon/actions/build-lectures@v0
       with:
         builder: 'html'
         source-dir: ${{ inputs.source-dir }}
@@ -266,8 +266,11 @@ runs:
     # UPLOAD ARTIFACT
     # ============================================================
     
-    - name: Upload build artifact
-      if: inputs.upload-artifact == 'true'
+    - name: Upload build artifact (on failure, for debugging)
+      # On success the GHA cache already holds _build, so skip the redundant
+      # 30-day artifact; only upload when a build failed (the cache is not saved
+      # then), making the artifact the sole copy for debugging.
+      if: inputs.upload-artifact == 'true' && steps.verify-builds.outputs.all-passed != 'true'
       uses: actions/upload-artifact@v4
       with:
         name: build-cache-${{ github.run_id }}

--- a/publish-gh-pages/action.yml
+++ b/publish-gh-pages/action.yml
@@ -162,7 +162,7 @@ runs:
         if [ -n "${{ inputs.cname }}" ]; then
           echo "🌐 Custom domain: ${{ inputs.cname }}"
         fi
-        if [ "${{ inputs.create-release-assets }}" == "true" ]; then
+        if [ "${{ steps.create-assets.outputs.assets-created }}" == "true" ]; then
           echo "📦 Release assets uploaded to: https://github.com/$GITHUB_REPOSITORY/releases/tag/$GITHUB_REF_NAME"
         fi
         echo "::endgroup::"

--- a/publish-gh-pages/action.yml
+++ b/publish-gh-pages/action.yml
@@ -81,7 +81,22 @@ runs:
       id: create-assets
       if: inputs.create-release-assets == 'true'
       shell: bash
+      env:
+        RELEASE_TOKEN: ${{ inputs.github-token }}
       run: |
+        # Guard: release assets need a tag trigger and a token. Skip cleanly
+        # off-tag; fail fast on a missing token (clear misconfiguration) so the
+        # upload step does not error mid-flight.
+        if [ "$GITHUB_REF_TYPE" != "tag" ]; then
+          echo "::warning::create-release-assets is enabled but this run was not triggered by a tag (GITHUB_REF_TYPE='$GITHUB_REF_TYPE'); skipping release assets."
+          echo "assets-created=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        if [ -z "$RELEASE_TOKEN" ]; then
+          echo "::error::create-release-assets is enabled but 'github-token' is empty. Pass a token via the github-token input (e.g. secrets.GITHUB_TOKEN)."
+          exit 1
+        fi
+
         # Determine asset name
         ASSET_NAME="${{ inputs.asset-name }}"
         if [ -z "$ASSET_NAME" ]; then
@@ -95,14 +110,20 @@ runs:
         echo "📦 Creating release assets..."
         echo "   Archive: $ARCHIVE_NAME"
         
+        # Write assets to a temp dir OUTSIDE build-dir so the growing tarball
+        # can't recurse into itself when build-dir is the cwd or a parent.
+        ARCHIVE_PATH="${RUNNER_TEMP}/${ARCHIVE_NAME}"
+        CHECKSUM_PATH="${RUNNER_TEMP}/${ASSET_NAME}-checksum.txt"
+        MANIFEST_PATH="${RUNNER_TEMP}/${ASSET_NAME}-manifest.json"
+
         # Create tarball
-        tar -czf "$ARCHIVE_NAME" -C "${{ inputs.build-dir }}" .
-        
-        # Create checksum
-        sha256sum "$ARCHIVE_NAME" > "${ASSET_NAME}-checksum.txt"
-        
+        tar -czf "$ARCHIVE_PATH" -C "${{ inputs.build-dir }}" .
+
+        # Create checksum (reference just the archive filename, not the path)
+        ( cd "${RUNNER_TEMP}" && sha256sum "$ARCHIVE_NAME" > "$CHECKSUM_PATH" )
+
         # Create manifest
-        cat > "${ASSET_NAME}-manifest.json" << EOF
+        cat > "$MANIFEST_PATH" << EOF
         {
           "name": "$ASSET_NAME",
           "tag": "$TAG_NAME",
@@ -114,14 +135,15 @@ runs:
         }
         EOF
         
-        echo "archive-name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
-        echo "checksum-name=${ASSET_NAME}-checksum.txt" >> $GITHUB_OUTPUT
-        echo "manifest-name=${ASSET_NAME}-manifest.json" >> $GITHUB_OUTPUT
+        echo "assets-created=true" >> $GITHUB_OUTPUT
+        echo "archive-name=$ARCHIVE_PATH" >> $GITHUB_OUTPUT
+        echo "checksum-name=$CHECKSUM_PATH" >> $GITHUB_OUTPUT
+        echo "manifest-name=$MANIFEST_PATH" >> $GITHUB_OUTPUT
         echo "✅ Release assets created"
 
     - name: Upload release assets
       id: upload-release
-      if: inputs.create-release-assets == 'true'
+      if: inputs.create-release-assets == 'true' && steps.create-assets.outputs.assets-created == 'true'
       uses: softprops/action-gh-release@v2
       with:
         files: |


### PR DESCRIPTION
Closes #38 (H8, M14, M15, M16).

## ⚠️ H8 — corrected fix (relative paths → `@v0`)

The issue (and my original review) proposed switching `build-jupyter-cache`'s sibling calls to relative `./` paths. **That would have broken every consumer:** inside a composite action, `uses: ./setup-environment` resolves against the *consumer's* `$GITHUB_WORKSPACE`, not this repo — a documented runner limitation ([actions/runner#1348](https://github.com/actions/runner/issues/1348), [#2101](https://github.com/actions/runner/issues/2101)).

So instead I pinned the four internal calls from `@main` → **`@v0`**. This keeps the working full-path reference while fixing the actual risk (a pinned `build-jupyter-cache@v0.x` no longer transitively runs unreleased `main`). It tracks the floating release tag, consistent with how consumers reference these actions.

## M14 — artifact only on failure

`build-jupyter-cache` saved `_build` to the GHA cache **and** uploaded it as a 30-day artifact on every run (`upload-artifact` default `true`), duplicating ~150 MB. Now the artifact uploads **only when a build fails** — exactly when it's useful, since the cache isn't saved on failure. On success the cache is the single copy. (`upload-artifact: false` still suppresses it entirely.)

## M15 — release tarball can't include itself

`publish-gh-pages` ran `tar -czf "$ARCHIVE_NAME" -C build-dir .` in the cwd, so if `build-dir` was the cwd/parent the growing archive could recurse into itself. The tarball, checksum, and manifest are now written to `$RUNNER_TEMP` (outside `build-dir`); the checksum still references just the archive filename.

## M16 — guard `create-release-assets`

Previously no tag/token guard, so enabling it without a tag or token failed confusingly mid-upload. Now it:
- **skips cleanly off-tag** (warning + `assets-created=false`);
- **fails fast** if `github-token` is empty (checked via an env var, not inlined into the script);
- gates the upload step on assets actually being created.

## Verification
- Both action YAMLs validated.
- H8: 4 internal refs now `@v0`, no `@main` remaining.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)