### PR TITLE
Pin Miniconda + apt-get clean in full container, matching lean (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **build-jupyter-cache**: The `_build` artifact is now uploaded only when a build fails (for
   debugging), instead of duplicating the cached `_build` into a 30-day artifact on every successful
   run. (#38, M14)
+- **Containers**: Pinned Miniconda in the full `quantecon` image to a specific version + SHA256
+  (matching the lean `quantecon-build` image) for supply-chain security and reproducibility, and
+  added `apt-get clean` for image-size parity. (#32, C2/L20)
 
 ## [0.7.0] - 2026-06-16
 

--- a/containers/quantecon/Dockerfile
+++ b/containers/quantecon/Dockerfile
@@ -42,7 +42,8 @@ RUN apt-get update && \
         libpango-1.0-0 \
         libcairo2 \
         libasound2t64 \
-        && rm -rf /var/lib/apt/lists/*
+        && rm -rf /var/lib/apt/lists/* \
+        && apt-get clean
 
 # Copy FreeSerif fonts to TeX's font directory (fixes latexmk subprocess font access)
 # This ensures fonts are found even when latexmk spawns xelatex with different environment
@@ -70,8 +71,13 @@ ENV FONTCONFIG_PATH=/etc/fonts
 ENV FONTCONFIG_FILE=/etc/fonts/fonts.conf
 
 # Install Miniconda
+# Pinned to specific version with SHA256 checksum for supply-chain security
+# (kept in sync with containers/quantecon-build/Dockerfile)
 ENV CONDA_DIR=/opt/conda
-RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh && \
+ENV MINICONDA_VERSION=py313_25.11.1-1
+ENV MINICONDA_SHA256=e0b10e050e8928e2eb9aad2c522ee3b5d31d30048b8a9997663a8a460d538cef
+RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -o /tmp/miniconda.sh && \
+    echo "${MINICONDA_SHA256}  /tmp/miniconda.sh" | sha256sum -c - && \
     bash /tmp/miniconda.sh -b -p /opt/conda && \
     rm /tmp/miniconda.sh
 


### PR DESCRIPTION
Closes #32 (C2, L20) — brings the full `quantecon` image's Miniconda install in line with the lean `quantecon-build` image.

## C2 — pin Miniconda + verify SHA256
The full image pulled `Miniconda3-latest-Linux-x86_64.sh` with **no checksum** — a supply-chain and reproducibility risk. Now it pins the exact version and verifies the SHA256, identical to the lean image:

```dockerfile
ENV MINICONDA_VERSION=py313_25.11.1-1
ENV MINICONDA_SHA256=e0b10e050e8928e2eb9aad2c522ee3b5d31d30048b8a9997663a8a460d538cef
RUN curl -L .../Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -o /tmp/miniconda.sh && \
    echo "${MINICONDA_SHA256}  /tmp/miniconda.sh" | sha256sum -c - && \
    ...
```

## L20 — `apt-get clean` parity
Added `apt-get clean` after `rm -rf /var/lib/apt/lists/*`, matching the lean image (small image-size win).

## Notes
- The pin is deliberately the **same** version + hash as `quantecon-build`, with a comment to keep them in sync. When bumping Miniconda, both Dockerfiles should move together.
- Verified the resulting install lines are byte-identical to the lean image.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)