### PR TITLE
Preview actions: share change-detection script + harden regex/script-injection (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   added `apt-get clean` for image-size parity. (#32, C2/L20)
 - **preview-netlify / preview-cloudflare**: De-duplicated the change-detection logic into a shared
   `scripts/detect-changed-lectures.sh`, and made it treat `lectures-dir` as a literal path instead
-  of a regex (a dir name with `.`/`+` etc. no longer misbehaves). (#35, M9/H7)
+  of a regex (a dir name with `.`/`+` etc. no longer misbehaves). The per-file "has changes" test
+  now uses `git diff --quiet` rather than parsing diff text, fixing a pre-existing edge case where a
+  file whose only changes were `---`/`+++`-style lines (e.g. front-matter delimiters) was wrongly
+  excluded. (#35, M9/H7)
 
 ### Security
 - **preview-netlify / preview-cloudflare**: PR-controlled values (changed file paths, deploy URL)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Containers**: Pinned Miniconda in the full `quantecon` image to a specific version + SHA256
   (matching the lean `quantecon-build` image) for supply-chain security and reproducibility, and
   added `apt-get clean` for image-size parity. (#32, C2/L20)
+- **preview-netlify / preview-cloudflare**: De-duplicated the change-detection logic into a shared
+  `scripts/detect-changed-lectures.sh`, and made it treat `lectures-dir` as a literal path instead
+  of a regex (a dir name with `.`/`+` etc. no longer misbehaves). (#35, M9/H7)
+
+### Security
+- **preview-netlify / preview-cloudflare**: PR-controlled values (changed file paths, deploy URL)
+  are now passed to the `github-script` PR-comment step via `env` and read from `process.env`
+  instead of being interpolated into the script body, closing a script-injection vector. (#35, N2)
 
 ## [0.7.0] - 2026-06-16
 

--- a/preview-cloudflare/action.yml
+++ b/preview-cloudflare/action.yml
@@ -50,63 +50,11 @@ runs:
       id: detect-changes
       if: steps.check-trust.outputs.skip != 'true' && inputs.lectures-dir != '' && github.event_name == 'pull_request'
       shell: bash
-      run: |
-        echo "Detecting changed lecture files in ${{ inputs.lectures-dir }}..."
-        
-        # Fetch base and head commits
-        git fetch origin ${{ github.event.pull_request.base.sha }}:refs/remotes/origin/pr-base 2>/dev/null || true
-        git fetch origin ${{ github.event.pull_request.head.sha }}:refs/remotes/origin/pr-head 2>/dev/null || true
-        
-        # Get changed files
-        all_changed=$(git diff --name-status ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} 2>/dev/null || echo "")
-        
-        if [ -z "$all_changed" ]; then
-          echo "No changes detected"
-          echo "changed-files=" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        # Filter for lecture files (Added or Modified, not Deleted)
-        lectures_dir="${{ inputs.lectures-dir }}"
-        changed_lecture_files=""
-        
-        while IFS=$'\t' read -r status file; do
-          [ -z "$status" ] && continue
-          
-          # Only include Added (A) or Modified (M) files in lectures dir
-          if [[ "$status" =~ ^[AM] ]] && [[ "$file" =~ ^${lectures_dir}/.*\.md$ ]] && [[ ! "$file" =~ ^${lectures_dir}/_ ]] && [[ "$file" != "${lectures_dir}/intro.md" ]]; then
-            if [ -f "$file" ]; then
-              # Verify actual content changes
-              content_diff=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- "$file" | grep -E '^[+-]' | grep -v '^[+-]{3}' | wc -l)
-              if [ "$content_diff" -gt 0 ]; then
-                echo "✓ Changed: $file"
-                if [ -z "$changed_lecture_files" ]; then
-                  changed_lecture_files="$file"
-                else
-                  changed_lecture_files="$changed_lecture_files"$'\n'"$file"
-                fi
-              fi
-            fi
-          fi
-        done <<< "$all_changed"
-        
-        if [ -n "$changed_lecture_files" ]; then
-          echo "changed-files<<EOF" >> $GITHUB_OUTPUT
-          echo "$changed_lecture_files" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-        else
-          echo "changed-files=" >> $GITHUB_OUTPUT
-        fi
-        
-        # Detect if _toc.yml is inside lectures-dir (strip dir from URL) or at root (keep dir)
-        # If _toc.yml is inside lectures-dir, Jupyter Book builds relative to that dir
-        if [ -f "${lectures_dir}/_toc.yml" ]; then
-          echo "strip-lectures-dir=true" >> $GITHUB_OUTPUT
-          echo "📁 _toc.yml found in ${lectures_dir}/ - will strip directory from URLs"
-        else
-          echo "strip-lectures-dir=false" >> $GITHUB_OUTPUT
-          echo "📁 _toc.yml not in ${lectures_dir}/ - will keep directory in URLs"
-        fi
+      env:
+        LECTURES_DIR: ${{ inputs.lectures-dir }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: bash "$GITHUB_ACTION_PATH/../scripts/detect-changed-lectures.sh"
 
     - name: Install Wrangler CLI
       if: steps.check-trust.outputs.skip != 'true'
@@ -166,15 +114,23 @@ runs:
     - name: Comment on PR
       if: steps.check-trust.outputs.skip != 'true' && github.event_name == 'pull_request' && steps.deploy.outputs.deploy-url != ''
       uses: actions/github-script@v7
+      env:
+        DEPLOY_URL: ${{ steps.deploy.outputs.deploy-url }}
+        CHANGED_FILES: ${{ steps.detect-changes.outputs.changed-files }}
+        LECTURES_DIR: ${{ inputs.lectures-dir }}
+        STRIP_LECTURES_DIR: ${{ steps.detect-changes.outputs.strip-lectures-dir }}
+        COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       with:
         github-token: ${{ github.token }}
         script: |
-          const deployUrl = '${{ steps.deploy.outputs.deploy-url }}';
-          const changedFiles = `${{ steps.detect-changes.outputs.changed-files }}`;
-          const lecturesDir = '${{ inputs.lectures-dir }}';
-          const stripLecturesDir = '${{ steps.detect-changes.outputs.strip-lectures-dir }}' === 'true';
+          // Untrusted PR data (file paths, deploy URL) is read from env, never
+          // interpolated into the script body (avoids script injection).
+          const deployUrl = process.env.DEPLOY_URL || '';
+          const changedFiles = process.env.CHANGED_FILES || '';
+          const lecturesDir = process.env.LECTURES_DIR || '';
+          const stripLecturesDir = process.env.STRIP_LECTURES_DIR === 'true';
           const prNumber = context.issue.number;
-          const commitSha = '${{ github.event.pull_request.head.sha }}';
+          const commitSha = process.env.COMMIT_SHA || '';
           const shortSha = commitSha.substring(0, 7);
           const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${commitSha}`;
           

--- a/preview-netlify/action.yml
+++ b/preview-netlify/action.yml
@@ -47,63 +47,11 @@ runs:
       id: detect-changes
       if: steps.check-trust.outputs.skip != 'true' && inputs.lectures-dir != '' && github.event_name == 'pull_request'
       shell: bash
-      run: |
-        echo "Detecting changed lecture files in ${{ inputs.lectures-dir }}..."
-        
-        # Fetch base and head commits
-        git fetch origin ${{ github.event.pull_request.base.sha }}:refs/remotes/origin/pr-base 2>/dev/null || true
-        git fetch origin ${{ github.event.pull_request.head.sha }}:refs/remotes/origin/pr-head 2>/dev/null || true
-        
-        # Get changed files
-        all_changed=$(git diff --name-status ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} 2>/dev/null || echo "")
-        
-        if [ -z "$all_changed" ]; then
-          echo "No changes detected"
-          echo "changed-files=" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        # Filter for lecture files (Added or Modified, not Deleted)
-        lectures_dir="${{ inputs.lectures-dir }}"
-        changed_lecture_files=""
-        
-        while IFS=$'\t' read -r status file; do
-          [ -z "$status" ] && continue
-          
-          # Only include Added (A) or Modified (M) files in lectures dir
-          if [[ "$status" =~ ^[AM] ]] && [[ "$file" =~ ^${lectures_dir}/.*\.md$ ]] && [[ ! "$file" =~ ^${lectures_dir}/_ ]] && [[ "$file" != "${lectures_dir}/intro.md" ]]; then
-            if [ -f "$file" ]; then
-              # Verify actual content changes
-              content_diff=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- "$file" | grep -E '^[+-]' | grep -v '^[+-]{3}' | wc -l)
-              if [ "$content_diff" -gt 0 ]; then
-                echo "✓ Changed: $file"
-                if [ -z "$changed_lecture_files" ]; then
-                  changed_lecture_files="$file"
-                else
-                  changed_lecture_files="$changed_lecture_files"$'\n'"$file"
-                fi
-              fi
-            fi
-          fi
-        done <<< "$all_changed"
-        
-        if [ -n "$changed_lecture_files" ]; then
-          echo "changed-files<<EOF" >> $GITHUB_OUTPUT
-          echo "$changed_lecture_files" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-        else
-          echo "changed-files=" >> $GITHUB_OUTPUT
-        fi
-        
-        # Detect if _toc.yml is inside lectures-dir (strip dir from URL) or at root (keep dir)
-        # If _toc.yml is inside lectures-dir, Jupyter Book builds relative to that dir
-        if [ -f "${lectures_dir}/_toc.yml" ]; then
-          echo "strip-lectures-dir=true" >> $GITHUB_OUTPUT
-          echo "📁 _toc.yml found in ${lectures_dir}/ - will strip directory from URLs"
-        else
-          echo "strip-lectures-dir=false" >> $GITHUB_OUTPUT
-          echo "📁 _toc.yml not in ${lectures_dir}/ - will keep directory in URLs"
-        fi
+      env:
+        LECTURES_DIR: ${{ inputs.lectures-dir }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: bash "$GITHUB_ACTION_PATH/../scripts/detect-changed-lectures.sh"
 
     - name: Install Netlify CLI
       if: steps.check-trust.outputs.skip != 'true'
@@ -152,15 +100,23 @@ runs:
     - name: Comment on PR
       if: steps.check-trust.outputs.skip != 'true' && github.event_name == 'pull_request' && steps.deploy.outputs.deploy-url != ''
       uses: actions/github-script@v7
+      env:
+        DEPLOY_URL: ${{ steps.deploy.outputs.deploy-url }}
+        CHANGED_FILES: ${{ steps.detect-changes.outputs.changed-files }}
+        LECTURES_DIR: ${{ inputs.lectures-dir }}
+        STRIP_LECTURES_DIR: ${{ steps.detect-changes.outputs.strip-lectures-dir }}
+        COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       with:
         github-token: ${{ github.token }}
         script: |
-          const deployUrl = '${{ steps.deploy.outputs.deploy-url }}';
-          const changedFiles = `${{ steps.detect-changes.outputs.changed-files }}`;
-          const lecturesDir = '${{ inputs.lectures-dir }}';
-          const stripLecturesDir = '${{ steps.detect-changes.outputs.strip-lectures-dir }}' === 'true';
+          // Untrusted PR data (file paths, deploy URL) is read from env, never
+          // interpolated into the script body (avoids script injection).
+          const deployUrl = process.env.DEPLOY_URL || '';
+          const changedFiles = process.env.CHANGED_FILES || '';
+          const lecturesDir = process.env.LECTURES_DIR || '';
+          const stripLecturesDir = process.env.STRIP_LECTURES_DIR === 'true';
           const prNumber = context.issue.number;
-          const commitSha = '${{ github.event.pull_request.head.sha }}';
+          const commitSha = process.env.COMMIT_SHA || '';
           const shortSha = commitSha.substring(0, 7);
           const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${commitSha}`;
           

--- a/scripts/detect-changed-lectures.sh
+++ b/scripts/detect-changed-lectures.sh
@@ -46,11 +46,10 @@ if [ -n "$all_changed" ]; then
     [[ "$file" != "$lectures_dir/intro.md" ]] || continue
     [ -f "$file" ] || continue
 
-    # Require actual content changes (ignore pure rename/metadata diffs).
-    content_diff=$(git diff "${BASE_SHA}..${HEAD_SHA}" -- "$file" \
-      | grep -E '^[+-]' | grep -vE '^[+-]{3}' | wc -l)
-    content_diff=$(echo "$content_diff" | tr -d '[:space:]')
-    if [ "${content_diff:-0}" -gt 0 ]; then
+    # Include the file if it has any real diff between the two commits.
+    # (Don't parse diff text: a content line such as a '---' front-matter
+    # delimiter shows up as '+---' and could be mis-filtered as a header.)
+    if ! git diff --quiet "${BASE_SHA}..${HEAD_SHA}" -- "$file"; then
       echo "✓ Changed: $file"
       if [ -z "$changed_lecture_files" ]; then
         changed_lecture_files="$file"

--- a/scripts/detect-changed-lectures.sh
+++ b/scripts/detect-changed-lectures.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Detect added/modified lecture .md files between a PR's base and head commit.
+# Shared by the preview-netlify and preview-cloudflare actions so the change
+# detection (and its filtering rules) live in one place.
+#
+# Inputs (environment variables):
+#   LECTURES_DIR  - directory holding lecture .md files (e.g. "lectures")
+#   BASE_SHA      - PR base commit SHA
+#   HEAD_SHA      - PR head commit SHA
+#
+# Outputs (appended to $GITHUB_OUTPUT):
+#   changed-files       - newline-separated list of changed lecture files
+#   strip-lectures-dir  - "true" if _toc.yml lives inside LECTURES_DIR
+#
+# Note: lectures_dir is treated as a *literal* path (quoted-glob matching),
+# not a regex, so values containing regex metacharacters behave correctly.
+
+: "${BASE_SHA:?BASE_SHA is required}"
+: "${HEAD_SHA:?HEAD_SHA is required}"
+lectures_dir="${LECTURES_DIR:-lectures}"
+
+echo "Detecting changed lecture files in ${lectures_dir}..."
+
+# Make sure both endpoints are available locally (best effort).
+git fetch origin "${BASE_SHA}:refs/remotes/origin/pr-base" 2>/dev/null || true
+git fetch origin "${HEAD_SHA}:refs/remotes/origin/pr-head" 2>/dev/null || true
+
+all_changed=$(git diff --name-status "${BASE_SHA}..${HEAD_SHA}" 2>/dev/null || echo "")
+
+changed_lecture_files=""
+if [ -n "$all_changed" ]; then
+  while IFS=$'\t' read -r status file; do
+    [ -z "$status" ] && continue
+
+    # Only Added (A) or Modified (M) files.
+    case "$status" in
+      A*|M*) ;;
+      *) continue ;;
+    esac
+
+    # Path filters — quoted "$lectures_dir" keeps it literal, so a dir name
+    # with '.', '+', etc. doesn't act as a regex.
+    [[ "$file" == "$lectures_dir"/*.md ]] || continue   # under lectures dir, .md
+    [[ "$file" != "$lectures_dir"/_* ]]   || continue   # skip _config, _toc, ...
+    [[ "$file" != "$lectures_dir/intro.md" ]] || continue
+    [ -f "$file" ] || continue
+
+    # Require actual content changes (ignore pure rename/metadata diffs).
+    content_diff=$(git diff "${BASE_SHA}..${HEAD_SHA}" -- "$file" \
+      | grep -E '^[+-]' | grep -vE '^[+-]{3}' | wc -l)
+    content_diff=$(echo "$content_diff" | tr -d '[:space:]')
+    if [ "${content_diff:-0}" -gt 0 ]; then
+      echo "✓ Changed: $file"
+      if [ -z "$changed_lecture_files" ]; then
+        changed_lecture_files="$file"
+      else
+        changed_lecture_files="${changed_lecture_files}"$'\n'"$file"
+      fi
+    fi
+  done <<< "$all_changed"
+fi
+
+if [ -n "$changed_lecture_files" ]; then
+  {
+    echo "changed-files<<EOF"
+    echo "$changed_lecture_files"
+    echo "EOF"
+  } >> "$GITHUB_OUTPUT"
+else
+  echo "changed-files=" >> "$GITHUB_OUTPUT"
+fi
+
+if [ -f "${lectures_dir}/_toc.yml" ]; then
+  echo "strip-lectures-dir=true" >> "$GITHUB_OUTPUT"
+  echo "📁 _toc.yml found in ${lectures_dir}/ - will strip directory from URLs"
+else
+  echo "strip-lectures-dir=false" >> "$GITHUB_OUTPUT"
+  echo "📁 _toc.yml not in ${lectures_dir}/ - will keep directory in URLs"
+fi


### PR DESCRIPTION
Closes #35 (M9, H7, N2) — the **pragmatic de-dup** we agreed on: extract the genuinely-shared change-detection into one script (fixing H7 once), harden N2 in both comment steps, and leave the bits that legitimately differ (netlify CLI vs wrangler, marker emoji).

## M9 — shared change-detection
The ~60 lines of identical change-detection are now `scripts/detect-changed-lectures.sh`, called by both actions:
```yaml
env:
  LECTURES_DIR: ${{ inputs.lectures-dir }}
  BASE_SHA: ${{ github.event.pull_request.base.sha }}
  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
run: bash "$GITHUB_ACTION_PATH/../scripts/detect-changed-lectures.sh"
```
Each action drops ~57 lines. The deploy + PR-comment steps stay per-action.

## H7 — `lectures-dir` treated as a literal path
The old check interpolated `lectures-dir` into a bash **regex** (`^${lectures_dir}/.*\.md$`). The shared script uses quoted-glob matching, so a dir name with regex metacharacters behaves correctly. Unit-tested:
- `lectures/aiyagari.md`, `lectures/sub/nested.md` → included
- `lectures/_static/x.md`, `lectures/intro.md`, `lectures/notes.txt`, `other/foo.md` → skipped
- with `lectures-dir: "lec.tures"`, `lecXtures/foo.md` → **skipped** (the old regex would have wrongly matched the `.`)

## N2 (security) — no untrusted data in the script body
The `github-script` comment step interpolated PR-controlled values (`changed-files` = file paths, `deploy-url`) directly into the JS template, a script-injection vector. They're now passed via `env` and read from `process.env`:
```js
const changedFiles = process.env.CHANGED_FILES || '';
const deployUrl = process.env.DEPLOY_URL || '';
```
(It was already gated by the trusted-actor check, so exploitation needed repo push access — this removes the anti-pattern regardless.)

## Notes / verification
- Behavior preserved — the script is the same logic (no `set -e`/`pipefail`, so a `grep` no-match still yields `0` like before), plus the H7 fix.
- Both action YAMLs validated; `bash -n` clean; no `${{ … }}` interpolation remains inside either `script:` body.
- Deliberately did **not** share the PR-comment github-script (it differs by marker/title, and sharing JS via `github.action_path`/`require` adds the kind of path indirection we just got bitten by in #38). That was the "full consolidation" option we set aside.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)