### PR TITLE
Add Dependabot: conda environments, third-party actions, and base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot keeps the container conda environments' Python packages current.
+#
+# The conda ecosystem (GA Dec 2025) resolves Python packages via PyPI — it
+# tracks the `pip:` block (jupyter-book, quantecon-book-theme, the sphinx-*
+# extensions, kaleido) and Python conda deps. Conda-only entries such as the
+# `anaconda` metapackage and `nodejs` are not on PyPI and won't be updated.
+#
+# Dependabot PRs run as `dependabot[bot]`, which the preview-* actions already
+# skip (no secret access), so these PRs won't trigger preview deploys.
+version: 2
+updates:
+  - package-ecosystem: "conda"
+    directories:
+      - "/containers/quantecon"
+      - "/containers/quantecon-build"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "maintenance"
+    commit-message:
+      prefix: "deps"
+    # Python is pinned deliberately (matched to the image base); let us bump it
+    # manually rather than via automated PRs.
+    ignore:
+      - dependency-name: "python"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
-# Dependabot keeps the container conda environments' Python packages current.
-#
-# The conda ecosystem (GA Dec 2025) resolves Python packages via PyPI — it
-# tracks the `pip:` block (jupyter-book, quantecon-book-theme, the sphinx-*
-# extensions, kaleido) and Python conda deps. Conda-only entries such as the
-# `anaconda` metapackage and `nodejs` are not on PyPI and won't be updated.
+# Dependabot configuration.
 #
 # Dependabot PRs run as `dependabot[bot]`, which the preview-* actions already
 # skip (no secret access), so these PRs won't trigger preview deploys.
 version: 2
 updates:
+  # ── Conda environments (container images) ──────────────────────────────────
+  # The conda ecosystem (GA Dec 2025) resolves Python packages via PyPI — it
+  # tracks the `pip:` block (jupyter-book, quantecon-book-theme, the sphinx-*
+  # extensions, kaleido) and Python conda deps. Conda-only entries such as the
+  # `anaconda` metapackage and `nodejs` are not on PyPI and won't be updated.
   - package-ecosystem: "conda"
     directories:
       - "/containers/quantecon"
@@ -24,3 +24,43 @@ updates:
     # manually rather than via automated PRs.
     ignore:
       - dependency-name: "python"
+
+  # ── Third-party GitHub Actions ─────────────────────────────────────────────
+  # "/" covers .github/workflows/; for github-actions, composite actions in
+  # subdirectories must each be listed explicitly (Dependabot only scans the
+  # given directory's action.yml, not nested ones).
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/setup-environment"
+      - "/build-lectures"
+      - "/build-jupyter-cache"
+      - "/restore-jupyter-cache"
+      - "/preview-netlify"
+      - "/preview-cloudflare"
+      - "/publish-gh-pages"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "maintenance"
+    commit-message:
+      prefix: "ci"
+    ignore:
+      # Don't propose bumps to our own internal sibling references (floating @v0).
+      - dependency-name: "quantecon/actions*"
+
+  # ── Container base image ───────────────────────────────────────────────────
+  # Tracks the `FROM ubuntu:24.04` base in each Dockerfile (not the Miniconda
+  # installer, which is pinned + checksummed in the RUN step).
+  - package-ecosystem: "docker"
+    directories:
+      - "/containers/quantecon"
+      - "/containers/quantecon-build"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "maintenance"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
Adds `.github/dependabot.yml` with **three** ecosystems to keep the repo's dependencies current.

Dependabot PRs run as `dependabot[bot]`, which the `preview-*` actions already skip (no secret access), so these PRs won't trigger preview deploys.

## 1. `conda` — container environments
Watches `containers/quantecon/environment.yml` and `containers/quantecon-build/environment.yml`. The conda ecosystem (GA Dec 2025, [changelog](https://github.blog/changelog/2025-12-16-conda-ecosystem-support-for-dependabot-now-generally-available/)) resolves **Python packages via PyPI** — i.e. the `pip:` toolchain (`jupyter-book`, `quantecon-book-theme`, the `sphinx-*` extensions, `kaleido`), exactly what was bumped by hand for 0.7.0.

Out of scope: conda-only entries (`anaconda` metapackage, `nodejs`) aren't on PyPI; `python` is `ignore`d so the version stays pinned under our control.

This complements the pinned Miniconda installer (#45): pin for reproducible/verifiable builds, and let Dependabot propose the package bumps so the env doesn't silently drift.

## 2. `github-actions` — third-party actions
Covers `.github/workflows/` **and** each composite-action subdir (they must be listed individually — Dependabot only scans the named directory's `action.yml`, not nested ones). Tracks `actions/cache`, `actions/*-pages`, `actions/github-script`, `actions/upload-artifact`, `conda-incubator/setup-miniconda`, `softprops/action-gh-release`, `docker/*`, `actions/checkout`. Our own internal `quantecon/actions@v0` sibling refs are `ignore`d so Dependabot doesn't fight the floating tag.

This is the **Dependabot half of #39** (the SHA-pinning piece is still separate).

## 3. `docker` — base image
Tracks the `FROM ubuntu:24.04` base image in both Dockerfiles (not the Miniconda installer, which is pinned + checksummed in the RUN step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)