### PR TITLE
build-lectures: drop eval, quote path inputs (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **publish-gh-pages**: Release tarball is written to `$RUNNER_TEMP` (outside `build-dir`) so the
   archive can't recurse into itself (#38, M15); `create-release-assets` now skips off-tag and fails
   fast when `github-token` is missing, instead of erroring mid-upload (#38, M16).
+- **build-lectures**: The build command no longer uses `eval`; it invokes `jb build` directly with
+  the source/output directories passed via `env` and quoted, so paths with spaces/metacharacters are
+  handled safely. The `output-dir` default changed from `./` to `.` (drops the `.//_build`
+  double-slash). `extra-args` is still word-split (documented in the step). (#36, M10/L17/L22)
 
 ### Changed
 - **restore-jupyter-cache**: Documented the optional `save-cache` input (PR-scoped saving) and

--- a/build-lectures/README.md
+++ b/build-lectures/README.md
@@ -21,8 +21,8 @@ Builds QuantEcon lectures using Jupyter Book.
 |-------|-------------|----------|---------|
 | `builder` | Jupyter Book builder (html/pdflatex/jupyter) | No | `html` |
 | `source-dir` | Directory containing lecture files | No | `lectures` |
-| `output-dir` | Base output directory | No | `./` |
-| `extra-args` | Extra jupyter-book build arguments | No | `-W --keep-going` |
+| `output-dir` | Base output directory | No | `.` |
+| `extra-args` | Extra jupyter-book build arguments (passed unquoted, so multiple flags word-split; quoted args with spaces are not supported) | No | `-W --keep-going` |
 | `html-copy-pdf` | Copy PDFs to `_build/html/_pdf/` (HTML only) | No | `false` |
 | `html-copy-notebooks` | Copy notebooks to `_build/html/_notebooks/` (HTML only) | No | `false` |
 | `upload-failure-reports` | Upload execution reports on failure | No | `false` |

--- a/build-lectures/action.yml
+++ b/build-lectures/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: '.'
   extra-args:
-    description: 'Extra arguments to pass to jupyter-book build'
+    description: 'Extra arguments to pass to jupyter-book build. Passed unquoted so multiple flags word-split (e.g. "-W --keep-going"); quoted arguments containing spaces are not supported.'
     required: false
     default: '-W --keep-going'
   html-copy-pdf:
@@ -118,13 +118,19 @@ runs:
         BUILD_EXIT_CODE=$?
         set -e
 
-        # Set output paths regardless of success/failure
+        # Set output path regardless of success/failure (compute once; write
+        # with the heredoc delimiter form so it's robust to odd characters).
         case "$BUILDER" in
-          html)     echo "build-path=${OUTPUT_DIR}/_build/html" >> "$GITHUB_OUTPUT" ;;
-          pdflatex) echo "build-path=${OUTPUT_DIR}/_build/latex" >> "$GITHUB_OUTPUT" ;;
-          jupyter)  echo "build-path=${OUTPUT_DIR}/_build/jupyter" >> "$GITHUB_OUTPUT" ;;
-          *)        echo "build-path=${OUTPUT_DIR}/_build" >> "$GITHUB_OUTPUT" ;;
+          html)     build_path="${OUTPUT_DIR}/_build/html" ;;
+          pdflatex) build_path="${OUTPUT_DIR}/_build/latex" ;;
+          jupyter)  build_path="${OUTPUT_DIR}/_build/jupyter" ;;
+          *)        build_path="${OUTPUT_DIR}/_build" ;;
         esac
+        {
+          echo "build-path<<EOF"
+          echo "$build_path"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
 
         # Exit with build exit code
         exit $BUILD_EXIT_CODE

--- a/build-lectures/action.yml
+++ b/build-lectures/action.yml
@@ -18,7 +18,7 @@ inputs:
   output-dir:
     description: 'Output directory for build artifacts'
     required: false
-    default: './'
+    default: '.'
   extra-args:
     description: 'Extra arguments to pass to jupyter-book build'
     required: false
@@ -89,42 +89,43 @@ runs:
     - name: Build lectures
       id: build
       shell: bash -l {0}
+      env:
+        BUILDER: ${{ inputs.builder }}
+        SOURCE_DIR: ${{ inputs.source-dir }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+        EXTRA_ARGS: ${{ inputs.extra-args }}
       run: |
-        echo "Building with builder: ${{ inputs.builder }}"
-        
-        # Set build command based on builder type
-        if [ "${{ inputs.builder }}" = "html" ]; then
-          BUILD_CMD="jb build ${{ inputs.source-dir }} --path-output ${{ inputs.output-dir }} ${{ inputs.extra-args }}"
-        elif [ "${{ inputs.builder }}" = "pdflatex" ]; then
-          BUILD_CMD="jb build ${{ inputs.source-dir }} --builder pdflatex --path-output ${{ inputs.output-dir }} -n ${{ inputs.extra-args }}"
-        elif [ "${{ inputs.builder }}" = "jupyter" ]; then
-          BUILD_CMD="jb build ${{ inputs.source-dir }} --path-output ${{ inputs.output-dir }} --builder=custom --custom-builder=jupyter -n ${{ inputs.extra-args }}"
-        else
-          # Custom builder
-          BUILD_CMD="jb build ${{ inputs.source-dir }} --builder ${{ inputs.builder }} --path-output ${{ inputs.output-dir }} ${{ inputs.extra-args }}"
-        fi
-        
+        echo "Building with builder: $BUILDER"
+
+        # Builder-specific flags as an array — no eval, and paths stay quoted.
+        case "$BUILDER" in
+          html)     builder_args=() ;;
+          pdflatex) builder_args=(--builder pdflatex -n) ;;
+          jupyter)  builder_args=(--builder=custom --custom-builder=jupyter -n) ;;
+          *)        builder_args=(--builder "$BUILDER") ;;
+        esac
+
+        # EXTRA_ARGS is intentionally left unquoted so it word-splits into
+        # separate flags (e.g. "-W --keep-going"); quoted args with embedded
+        # spaces inside EXTRA_ARGS are not supported.
         echo "::group::Build Command"
-        echo "$BUILD_CMD"
+        echo "jb build $SOURCE_DIR --path-output $OUTPUT_DIR ${builder_args[*]} $EXTRA_ARGS"
         echo "::endgroup::"
-        
+
         # Execute build and capture exit code
         set +e
-        eval $BUILD_CMD
+        jb build "$SOURCE_DIR" --path-output "$OUTPUT_DIR" "${builder_args[@]}" $EXTRA_ARGS
         BUILD_EXIT_CODE=$?
         set -e
-        
+
         # Set output paths regardless of success/failure
-        if [ "${{ inputs.builder }}" = "html" ]; then
-          echo "build-path=${{ inputs.output-dir }}/_build/html" >> $GITHUB_OUTPUT
-        elif [ "${{ inputs.builder }}" = "pdflatex" ]; then
-          echo "build-path=${{ inputs.output-dir }}/_build/latex" >> $GITHUB_OUTPUT
-        elif [ "${{ inputs.builder }}" = "jupyter" ]; then
-          echo "build-path=${{ inputs.output-dir }}/_build/jupyter" >> $GITHUB_OUTPUT
-        else
-          echo "build-path=${{ inputs.output-dir }}/_build" >> $GITHUB_OUTPUT
-        fi
-        
+        case "$BUILDER" in
+          html)     echo "build-path=${OUTPUT_DIR}/_build/html" >> "$GITHUB_OUTPUT" ;;
+          pdflatex) echo "build-path=${OUTPUT_DIR}/_build/latex" >> "$GITHUB_OUTPUT" ;;
+          jupyter)  echo "build-path=${OUTPUT_DIR}/_build/jupyter" >> "$GITHUB_OUTPUT" ;;
+          *)        echo "build-path=${OUTPUT_DIR}/_build" >> "$GITHUB_OUTPUT" ;;
+        esac
+
         # Exit with build exit code
         exit $BUILD_EXIT_CODE
 


### PR DESCRIPTION
Closes #36 (M10, L17, L22) — shell-safety cleanup of `build-lectures`.

## M10 — drop `eval`, quote the path inputs
The build command was built by string interpolation and run through `eval $BUILD_CMD`, so a space or shell metacharacter in `source-dir`/`output-dir` would break the build. Now it invokes `jb build` directly:
```bash
jb build "$SOURCE_DIR" --path-output "$OUTPUT_DIR" "${builder_args[@]}" $EXTRA_ARGS
```
- `source-dir`/`output-dir`/`builder`/`extra-args` are passed via `env:` and the paths are quoted.
- builder-specific flags live in a bash **array** (`builder_args`), so no `eval`.
- the if/elif ladder became a `case`.

## L17 — `output-dir` default `./` → `.`
Drops the cosmetic `.//_build/html` double-slash in the build path.

## L22 — `extra-args` word-splitting (documented)
`$EXTRA_ARGS` is left **unquoted** on purpose so `-W --keep-going` splits into two flags. A comment in the step notes that quoted args with embedded spaces inside `extra-args` aren't supported (the standard CI caveat).

## Verification
- YAML validated; `bash -n` clean on the new logic; no `eval` remains.
- Behavior preserved — flag order is irrelevant to `jb`, and each builder expands to the same command as before, e.g. pdflatex → `jb build lectures --path-output . --builder pdflatex -n -W --keep-going`.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)