### PR TITLE
Docs: sweep stale references and inconsistencies (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,11 +56,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swept the docs for stale references and inconsistencies (#40, D24–D34): replaced dead workflow /
   template / file references (`containers/VALIDATION.md`'s fictional builder pipeline → the real
   `test-containers-lectures.yml`; `cache-standard.yml`; `Dockerfile.gpu` / `environment-gpu.yml`);
-  standardised the container sizes (~3 GB lean / ~8 GB full) across README / ARCHITECTURE /
-  CONTAINER-GUIDE and documented the lean image in the Container Guide; refreshed the README status
-  line and switched its usage examples from `@main` to `@v0`; documented `failure-artifact-name` in
-  QUICK-REFERENCE; clarified in MIGRATION-GUIDE that the container workflow is the recommended path;
-  and fixed a mangled code fence in TESTING.md.
+  corrected the container sizes from measured values (lean ~7.1 GB / full ~8.3 GB on disk, ~2.9 /
+  ~3.2 GB compressed pull — the old docs mixed compressed and on-disk metrics) across README /
+  ARCHITECTURE / CONTAINER-GUIDE and documented the lean image in the Container Guide; refreshed the
+  README status line and switched its usage examples from `@main` to `@v0`; documented
+  `failure-artifact-name` in QUICK-REFERENCE; clarified in MIGRATION-GUIDE that the container
+  workflow is the recommended path; replaced the README "Usage by Repository" list with a pointer to
+  [QuantEcon/meta#321](https://github.com/QuantEcon/meta/issues/321); and fixed a mangled code fence
+  in TESTING.md.
 
 ## [0.7.0] - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are now passed to the `github-script` PR-comment step via `env` and read from `process.env`
   instead of being interpolated into the script body, closing a script-injection vector. (#35, N2)
 
+### Documentation
+- Swept the docs for stale references and inconsistencies (#40, D24–D34): replaced dead workflow /
+  template / file references (`containers/VALIDATION.md`'s fictional builder pipeline → the real
+  `test-containers-lectures.yml`; `cache-standard.yml`; `Dockerfile.gpu` / `environment-gpu.yml`);
+  standardised the container sizes (~3 GB lean / ~8 GB full) across README / ARCHITECTURE /
+  CONTAINER-GUIDE and documented the lean image in the Container Guide; refreshed the README status
+  line and switched its usage examples from `@main` to `@v0`; documented `failure-artifact-name` in
+  QUICK-REFERENCE; clarified in MIGRATION-GUIDE that the container workflow is the recommended path;
+  and fixed a mangled code fence in TESTING.md.
+
 ## [0.7.0] - 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ jobs:
 
 ### Container-Based Setup
 - Pre-built container images with LaTeX and Python environment
-- `ghcr.io/quantecon/quantecon:latest` - Full container (~8GB)
-- `ghcr.io/quantecon/quantecon-build:latest` - Lean container (~3GB)
+- `ghcr.io/quantecon/quantecon:latest` - Full image (~8.3 GB on disk, ~3.2 GB compressed pull)
+- `ghcr.io/quantecon/quantecon-build:latest` - Lean image (~7.1 GB on disk, ~2.9 GB compressed pull); drops the full Anaconda metapackage, so it's only modestly smaller
 - Setup time: ~2-3 minutes (container pull + lecture-specific packages)
 - Weekly automated builds (Monday 2am UTC) for security updates
 
@@ -165,12 +165,7 @@ Use `build-jupyter-cache` and `restore-jupyter-cache` actions for execution cach
 
 ## Usage by Repository
 
-These actions are used across the QuantEcon lecture repositories, including those exercised by the container test matrix:
-
-- **lecture-python-intro**
-- **lecture-python.myst**
-- **lecture-python-advanced.myst**
-- **lecture-jax** — GPU/JAX lectures (currently disabled in container CI pending [lecture-jax#284](https://github.com/QuantEcon/lecture-jax/issues/284))
+The lecture repositories that consume these actions are tracked centrally in [QuantEcon/meta#321](https://github.com/QuantEcon/meta/issues/321) (avoids maintaining a duplicate list here).
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Reusable composite GitHub Actions for building QuantEcon lecture repositories.
 
 This repository provides a set of composite actions that standardize and optimize the build process for QuantEcon lecture websites. These actions include intelligent caching strategies that significantly reduce build times.
 
-**Status:** Container infrastructure complete. Ready for testing with lecture repositories.
+**Status:** Stable; current release `v0.7.0` (see the [CHANGELOG](./CHANGELOG.md)).
 
 📋 **See:** [docs/CONTAINER-GUIDE.md](./docs/CONTAINER-GUIDE.md) for quick start, [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for design overview.
 
@@ -75,15 +75,15 @@ jobs:
           fetch-depth: 0
       
       # Restore cache from main branch builds
-      - uses: quantecon/actions/restore-jupyter-cache@main
+      - uses: quantecon/actions/restore-jupyter-cache@v0
         with:
           cache-type: 'build'
       
       # Build (uses restored cache for incremental build)
-      - uses: quantecon/actions/build-lectures@main
+      - uses: quantecon/actions/build-lectures@v0
         id: build
       
-      - uses: quantecon/actions/preview-netlify@main
+      - uses: quantecon/actions/preview-netlify@v0
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
@@ -113,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: quantecon/actions/build-jupyter-cache@main
+      - uses: quantecon/actions/build-jupyter-cache@v0
         with:
           builders: 'html'
           create-issue-on-failure: true
@@ -130,14 +130,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: quantecon/actions/setup-environment@main
+      - uses: quantecon/actions/setup-environment@v0
         with:
           python-version: '3.13'
           environment: 'environment.yml'  # Full installation from scratch
           install-latex: 'true'
           latex-requirements-file: 'latex-requirements.txt'
       
-      - uses: quantecon/actions/build-lectures@main
+      - uses: quantecon/actions/build-lectures@v0
 ```
 
 ## Performance Architecture
@@ -165,10 +165,12 @@ Use `build-jupyter-cache` and `restore-jupyter-cache` actions for execution cach
 
 ## Usage by Repository
 
-- **lecture-python.myst** - Requires ML libraries (JAX, PyTorch)
-- **lecture-python-programming.myst** - Standard environment
-- **lecture-python-intro** - Standard environment  
-- **lecture-python-advanced.myst** - Standard environment
+These actions are used across the QuantEcon lecture repositories, including those exercised by the container test matrix:
+
+- **lecture-python-intro**
+- **lecture-python.myst**
+- **lecture-python-advanced.myst**
+- **lecture-jax** — GPU/JAX lectures (currently disabled in container CI pending [lecture-jax#284](https://github.com/QuantEcon/lecture-jax/issues/284))
 
 ## Versioning
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -291,8 +291,9 @@ Track before/after migration:
 **Issue:** Conda solve fails or package conflicts
 
 **Debug:**
-    echo "Cache key: conda-${{ runner.os }}-${{ hashFiles('environment.yml') }}-v1"
-    ls -la ~/.conda/pkgs || echo "No conda cache"
+```bash
+echo "Cache key: conda-${{ runner.os }}-${{ hashFiles('environment.yml') }}-v1"
+ls -la ~/.conda/pkgs || echo "No conda cache"
 ```
 
 **Solution:** Check cache key format, verify paths

--- a/build-jupyter-cache/README.md
+++ b/build-jupyter-cache/README.md
@@ -208,8 +208,7 @@ The action generates a GitHub Actions summary showing:
 ## Workflow Templates
 
 See [templates/](../templates/) for complete workflow examples:
-- `cache.yml` - Using QuantEcon container
-- `cache-standard.yml` - Using ubuntu-latest
+- `cache.yml` - Container-based cache generation workflow
 
 ## Related Actions
 

--- a/containers/VALIDATION.md
+++ b/containers/VALIDATION.md
@@ -4,22 +4,11 @@ This document records validation test results for the QuantEcon containers acros
 
 ## Automated Testing
 
-**As of February 9, 2026:** Containers are now tested via a three-stage builder workflow pipeline, with artifact sharing to eliminate redundant notebook execution:
+Containers are tested by [`test-containers-lectures.yml`](../.github/workflows/test-containers-lectures.yml), which runs after the **Build QuantEcon Containers** workflow completes. Each job builds one lecture repo on one container through the full builder pipeline (HTML → pdflatex → jupyter) **sequentially**, reusing the executed notebooks across builders. Concurrency groups serialize jobs for the same repo to avoid network contention from concurrent dataset downloads; different repos run in parallel.
 
-- **Stage 1:** [`test-html-builder.yml`](../.github/workflows/test-html-builder.yml) - Execute notebooks + build HTML (8 jobs: 2 containers × 4 repos, max-parallel: 6)
-  - Uploads `_build/` artifacts for reuse
-- **Stage 2:** [`test-pdflatex-builder.yml`](../.github/workflows/test-pdflatex-builder.yml) - Build PDF from executed notebooks (8 jobs: 2 containers × 4 repos, max-parallel: 4)
-  - Downloads artifacts from Stage 1
-- **Stage 3:** [`test-jupyter-builder.yml`](../.github/workflows/test-jupyter-builder.yml) - MyST → Jupyter notebook conversion (8 jobs: 2 containers × 4 repos, max-parallel: 8)
-  - Downloads artifacts from Stage 1
+**Matrix:** 2 containers (`quantecon`, `quantecon-build`) × the QuantEcon lecture repos — `lecture-python-intro`, `lecture-python.myst`, `lecture-python-advanced.myst` (`lecture-jax` is temporarily disabled pending [lecture-jax#284](https://github.com/QuantEcon/lecture-jax/issues/284)).
 
-**Key improvements:**
-- Notebook execution: 8 times (once per container/repo) instead of 24 times
-- Intersphinx fetches: Reduced from 24 → 8 (major resilience improvement)
-- Temporal spreading: Tests run sequentially over 2-3 hours
-- Clear diagnostics: Execution failures caught in Stage 1, rendering issues in Stage 2/3
-
-**Manual testing:** [`test-all-containers.yml`](../.github/workflows/test-containers-lectures.yml) remains available for comprehensive manual testing (24 jobs total, executes notebooks 24 times).
+A companion workflow, [`test-container.yml`](../.github/workflows/test-container.yml), smoke-tests the freshly built images (XeLaTeX compile + a minimal Jupyter Book HTML/PDF build).
 
 ## Containers
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,11 +8,11 @@ Our next-generation CI/CD system combines three complementary elements:
 
 **Pre-built Docker images solve the LaTeX bottleneck:**
 
-- **Images:** `ghcr.io/quantecon/quantecon:latest` (CPU only - Phase 1)
+- **Images:** `ghcr.io/quantecon/quantecon:latest` (full) and `ghcr.io/quantecon/quantecon-build:latest` (lean) — CPU only
 - **Contents:** Ubuntu 24.04 LTS + TexLive (latest) + Miniconda + Anaconda 2025.12 base + Jupyter Book tools
 - **Build:** Weekly automated builds via GitHub Actions (Monday 2am UTC)
 - **Registry:** GitHub Container Registry (GHCR) - free for public repos
-- **Size:** ~8.3 GB full / ~7.1 GB lean `quantecon-build` on disk (~3 GB compressed pull; cached once by GitHub Actions runners)
+- **Size:** full ~8.3 GB / lean ~7.1 GB on disk (~3 GB compressed pull, fetched each run on GitHub-hosted runners)
 
 **Performance impact:**
 - ❌ Current: LaTeX setup takes 2-3 minutes every build
@@ -52,7 +52,7 @@ publish-gh-pages/     → Deploy to GitHub Pages
 - Where: GitHub Container Registry
 - Size: ~7.1 GB (lean) / ~8.3 GB (full) on disk; ~3 GB compressed pull
 - Lifespan: Weekly rebuilds
-- Pull time: ~20 seconds
+- Pull time: ~1-2 min on GitHub-hosted runners (~3 GB compressed, fetched each run); near-instant on self-hosted runners with the image pre-cached
 
 **Layer 2: Build Cache (GitHub Actions Cache)**
 - What: `_build/` directory from Jupyter Book
@@ -117,7 +117,7 @@ jobs:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    container: ghcr.io/quantecon/quantecon:latest  # 20 sec
+    container: ghcr.io/quantecon/quantecon:latest  # ~1-2 min pull
     steps:
       - uses: actions/checkout@v4
       
@@ -237,6 +237,8 @@ Total: 15-18 minutes
 ```
 
 ### Target Performance (Container + Cache)
+
+> These breakdowns assume the container image is already present locally (self-hosted or a warm/pre-cached runner, ~20 s). On GitHub-hosted runners add ~1-2 min for the per-run image pull.
 
 **First build (cold cache):**
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Our next-generation CI/CD system combines three complementary elements:
 - **Contents:** Ubuntu 24.04 LTS + TexLive (latest) + Miniconda + Anaconda 2025.12 base + Jupyter Book tools
 - **Build:** Weekly automated builds via GitHub Actions (Monday 2am UTC)
 - **Registry:** GitHub Container Registry (GHCR) - free for public repos
-- **Size:** ~2 GB (pulled once, cached by GitHub Actions runners)
+- **Size:** ~8 GB full image / ~3 GB lean `quantecon-build` (pulled once, cached by GitHub Actions runners)
 
 **Performance impact:**
 - ❌ Current: LaTeX setup takes 2-3 minutes every build
@@ -50,7 +50,7 @@ publish-gh-pages/     → Deploy to GitHub Pages
 **Layer 1: Environment Cache (Container Image)**
 - What: Python + LaTeX + all dependencies
 - Where: GitHub Container Registry
-- Size: ~2 GB
+- Size: ~3 GB (lean) / ~8 GB (full)
 - Lifespan: Weekly rebuilds
 - Pull time: ~20 seconds
 
@@ -183,7 +183,7 @@ jobs:
 - All lectures use same Python scientific stack (Anaconda base provides common packages)
 - Lecture-specific packages (quantecon, cvxpy, etc.) installed from each lecture's environment.yml
 - LaTeX requirements identical across all lectures
-- Disk space is cheap (2 GB acceptable)
+- Disk space is cheap (a few GB acceptable)
 - Massive reduction in complexity
 - Easy to update (one PR to container, lectures install their own dependencies)
 
@@ -283,11 +283,13 @@ Total: 30-40 seconds
 
 ```
 quantecon/actions/
-├── containers/quantecon/
-│   ├── Dockerfile                 # CPU: Ubuntu + LaTeX + Miniconda
-│   ├── Dockerfile.gpu             # GPU: CUDA base + same stack
-│   ├── environment.yml            # Centralized for all lectures
-│   └── environment-gpu.yml        # GPU-specific packages
+├── containers/
+│   ├── quantecon/                 # Full image (Ubuntu + LaTeX + Miniconda + Anaconda)
+│   │   ├── Dockerfile
+│   │   └── environment.yml
+│   └── quantecon-build/           # Lean image (build toolchain only)
+│       ├── Dockerfile
+│       └── environment.yml
 │
 ├── build-jupyter-cache/           # Modular action
 │   ├── action.yml                 # Generate cache on main branch

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Our next-generation CI/CD system combines three complementary elements:
 - **Contents:** Ubuntu 24.04 LTS + TexLive (latest) + Miniconda + Anaconda 2025.12 base + Jupyter Book tools
 - **Build:** Weekly automated builds via GitHub Actions (Monday 2am UTC)
 - **Registry:** GitHub Container Registry (GHCR) - free for public repos
-- **Size:** ~8 GB full image / ~3 GB lean `quantecon-build` (pulled once, cached by GitHub Actions runners)
+- **Size:** ~8.3 GB full / ~7.1 GB lean `quantecon-build` on disk (~3 GB compressed pull; cached once by GitHub Actions runners)
 
 **Performance impact:**
 - ❌ Current: LaTeX setup takes 2-3 minutes every build
@@ -50,7 +50,7 @@ publish-gh-pages/     → Deploy to GitHub Pages
 **Layer 1: Environment Cache (Container Image)**
 - What: Python + LaTeX + all dependencies
 - Where: GitHub Container Registry
-- Size: ~3 GB (lean) / ~8 GB (full)
+- Size: ~7.1 GB (lean) / ~8.3 GB (full) on disk; ~3 GB compressed pull
 - Lifespan: Weekly rebuilds
 - Pull time: ~20 seconds
 
@@ -183,7 +183,7 @@ jobs:
 - All lectures use same Python scientific stack (Anaconda base provides common packages)
 - Lecture-specific packages (quantecon, cvxpy, etc.) installed from each lecture's environment.yml
 - LaTeX requirements identical across all lectures
-- Disk space is cheap (a few GB acceptable)
+- Disk space is cheap (~7-8 GB acceptable)
 - Massive reduction in complexity
 - Easy to update (one PR to container, lectures install their own dependencies)
 

--- a/docs/CONTAINER-GUIDE.md
+++ b/docs/CONTAINER-GUIDE.md
@@ -4,14 +4,10 @@ Quick guide for using QuantEcon container infrastructure.
 
 ## What's Available
 
-**Container Image:** `ghcr.io/quantecon/quantecon:latest`
+Two container images (see [ARCHITECTURE.md](./ARCHITECTURE.md) for the rationale):
 
-**Includes:**
-- Ubuntu 24.04 LTS
-- TexLive (latest from Ubuntu repos)
-- Miniconda + Python 3.13
-- Anaconda 2025.12 (numpy, scipy, pandas, matplotlib, jupyter)
-- Jupyter Book 1.0.4post1 + extensions
+- **`ghcr.io/quantecon/quantecon:latest`** — full image (~8 GB): Ubuntu 24.04 LTS + TexLive + Miniconda/Python 3.13 + Anaconda 2025.12 (numpy, scipy, pandas, matplotlib, jupyter) + Jupyter Book 1.0.4post1 and extensions.
+- **`ghcr.io/quantecon/quantecon-build:latest`** — lean image (~3 GB): the build toolchain (LaTeX for PDF builds + Jupyter Book) without the full Anaconda metapackage; repos install their own packages from `environment.yml`.
 
 **Updates:** Weekly automated builds (Monday 2am UTC)
 
@@ -65,7 +61,7 @@ docker run -it --rm \
 | Base packages | 3-4 min | 0 min | Pre-installed in container |
 | **Total setup** | **7-8 min** | **~2 min** | **60-70% faster** |
 
-**Container initialization:** The 2-minute container load time is unavoidable on GitHub-hosted runners as the ~1.5-2GB image must be pulled from GHCR. However, this is still faster than installing LaTeX and Python packages separately.
+**Container initialization:** The 2-minute container load time is unavoidable on GitHub-hosted runners as the image (~3 GB lean / ~8 GB full) must be pulled from GHCR. However, this is still faster than installing LaTeX and Python packages separately.
 
 **For faster startup times:** Consider self-hosted runners where the container can be pre-pulled and cached locally, reducing initialization to < 10 seconds.
 

--- a/docs/CONTAINER-GUIDE.md
+++ b/docs/CONTAINER-GUIDE.md
@@ -6,8 +6,8 @@ Quick guide for using QuantEcon container infrastructure.
 
 Two container images (see [ARCHITECTURE.md](./ARCHITECTURE.md) for the rationale):
 
-- **`ghcr.io/quantecon/quantecon:latest`** — full image (~8 GB): Ubuntu 24.04 LTS + TexLive + Miniconda/Python 3.13 + Anaconda 2025.12 (numpy, scipy, pandas, matplotlib, jupyter) + Jupyter Book 1.0.4post1 and extensions.
-- **`ghcr.io/quantecon/quantecon-build:latest`** — lean image (~3 GB): the build toolchain (LaTeX for PDF builds + Jupyter Book) without the full Anaconda metapackage; repos install their own packages from `environment.yml`.
+- **`ghcr.io/quantecon/quantecon:latest`** — full image (~8.3 GB on disk, ~3.2 GB compressed pull): Ubuntu 24.04 LTS + TexLive + Miniconda/Python 3.13 + Anaconda 2025.12 (numpy, scipy, pandas, matplotlib, jupyter) + Jupyter Book 1.0.4post1 and extensions.
+- **`ghcr.io/quantecon/quantecon-build:latest`** — lean image (~7.1 GB on disk, ~2.9 GB compressed pull): the build toolchain (LaTeX for PDF builds + Jupyter Book) without the full Anaconda metapackage; repos install their own packages from `environment.yml`. (LaTeX dominates, so it's only modestly smaller than the full image.)
 
 **Updates:** Weekly automated builds (Monday 2am UTC)
 
@@ -61,7 +61,7 @@ docker run -it --rm \
 | Base packages | 3-4 min | 0 min | Pre-installed in container |
 | **Total setup** | **7-8 min** | **~2 min** | **60-70% faster** |
 
-**Container initialization:** The 2-minute container load time is unavoidable on GitHub-hosted runners as the image (~3 GB lean / ~8 GB full) must be pulled from GHCR. However, this is still faster than installing LaTeX and Python packages separately.
+**Container initialization:** The 2-minute container load time is unavoidable on GitHub-hosted runners as the compressed image (~2.9 GB lean / ~3.2 GB full) must be pulled from GHCR. However, this is still faster than installing LaTeX and Python packages separately.
 
 **For faster startup times:** Consider self-hosted runners where the container can be pre-pulled and cached locally, reducing initialization to < 10 seconds.
 

--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -29,7 +29,7 @@ Before starting migration:
 
 ## Quick Migration: Using setup-environment
 
-**Recommended approach:**
+> **Note:** For most repositories the **container-based** workflow is the recommended path — see [templates/ci.yml](../templates/ci.yml) and the [Container Guide](./CONTAINER-GUIDE.md). The `setup-environment` example below covers standard-runner (non-container) builds, or when you need full control over the environment.
 
 ### Before (Manual Setup)
 ```yaml

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -202,11 +202,12 @@ latex-requirements-file: 'latex-requirements.txt'  # LaTeX packages list
 ```yaml
 builder: 'html'                  # html|pdflatex|jupyter
 source-dir: 'lectures'           # Source directory
-output-dir: './'                 # Output base
+output-dir: '.'                  # Output base
 extra-args: '-W --keep-going'    # JB arguments
 html-copy-pdf: 'false'           # Copy PDFs to _build/html/_pdf/
 html-copy-notebooks: 'false'     # Copy notebooks to _build/html/_notebooks/
 upload-failure-reports: 'false'  # Upload reports on failure
+failure-artifact-name: ''        # Custom name for the failure-report artifact
 ```
 
 **Note:** Caching is handled separately via `build-jupyter-cache` and `restore-jupyter-cache`.


### PR DESCRIPTION
Closes #40 (D24–D34) — fixes dead references and inconsistencies across the docs.

## Dead/stale references fixed
- **D24** — `containers/VALIDATION.md` described a three-stage builder pipeline (`test-html-builder.yml`, …) that **doesn't exist** → replaced with the real `test-containers-lectures.yml` + `test-container.yml`.
- **D25** — `build-jupyter-cache/README.md` referenced a non-existent `cache-standard.yml`.
- **D26** — `docs/ARCHITECTURE.md` repo tree listed non-existent `Dockerfile.gpu` / `environment-gpu.yml` → replaced with the real `quantecon` + `quantecon-build` layout.
- **D30** — refreshed the stale README status line.
- **D33** — fixed a mangled code fence in `TESTING.md`.
- **D29** — documented `failure-artifact-name` (and corrected `output-dir`) in `QUICK-REFERENCE.md`.
- **D28** — `MIGRATION-GUIDE.md` no longer presents the non-container path as *the* recommendation.
- **Bonus** — README usage examples used `@main` → switched to `@v0` (the C1 sweep only touched `@v1`).

## Previously-flagged judgment calls — now resolved
- **D27 (container sizes) — measured, not guessed.** Pulled both images (amd64) and read the sizes: **lean 7.14 GB / full 8.34 GB on disk; 2.85 GB / 3.24 GB compressed pull.** The old "lean ~3 GB vs full ~8 GB" was **mixing metrics** (compressed-lean vs on-disk-full), implying a size gap that doesn't exist — LaTeX + the scientific stack dominate both, so "lean" is only modestly smaller. All size mentions now state both metrics explicitly.
- **D31 (consuming-repo list) — removed.** Per maintainer, the per-repo list is a maintenance burden; replaced with a pointer to [QuantEcon/meta#321](https://github.com/QuantEcon/meta/issues/321), which will track it centrally.

## Notes
- **D32** (duplicate build-time tables) turned out moot — `VALIDATION.md` has no build-time table.
- Docs-only; no action behavior changes.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)