### PR TITLE
Dependabot: group minor/patch per ecosystem; review majors individually

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,11 @@
 #
 # Dependabot PRs run as `dependabot[bot]`, which the preview-* actions already
 # skip (no secret access), so these PRs won't trigger preview deploys.
+#
+# Each ecosystem groups all of its updates into ONE pull request (a grouped PR
+# per ecosystem) instead of opening a separate PR per dependency. When this
+# config takes effect Dependabot supersedes and closes any existing individual
+# PRs, replacing them with the grouped ones.
 version: 2
 updates:
   # ── Conda environments (container images) ──────────────────────────────────
@@ -20,6 +25,10 @@ updates:
       - "maintenance"
     commit-message:
       prefix: "deps"
+    groups:
+      conda:
+        patterns:
+          - "*"
     # Python is pinned deliberately (matched to the image base); let us bump it
     # manually rather than via automated PRs.
     ignore:
@@ -46,6 +55,10 @@ updates:
       - "maintenance"
     commit-message:
       prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     ignore:
       # Don't propose bumps to our own internal sibling references (floating @v0).
       - dependency-name: "quantecon/actions*"
@@ -64,3 +77,7 @@ updates:
       - "maintenance"
     commit-message:
       prefix: "deps"
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,10 @@
 # Dependabot PRs run as `dependabot[bot]`, which the preview-* actions already
 # skip (no secret access), so these PRs won't trigger preview deploys.
 #
-# Each ecosystem groups all of its updates into ONE pull request (a grouped PR
-# per ecosystem) instead of opening a separate PR per dependency. When this
-# config takes effect Dependabot supersedes and closes any existing individual
+# Each ecosystem groups its minor/patch updates into one pull request (a grouped
+# PR per ecosystem) to cut noise; major updates come through as individual PRs
+# so each can be reviewed and accepted on its own. When this config takes
+# effect, Dependabot supersedes and closes the existing individual minor/patch
 # PRs, replacing them with the grouped ones.
 version: 2
 updates:
@@ -20,7 +21,7 @@ updates:
       - "/containers/quantecon-build"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - "maintenance"
     commit-message:
@@ -29,10 +30,15 @@ updates:
       conda:
         patterns:
           - "*"
-    # Python is pinned deliberately (matched to the image base); let us bump it
-    # manually rather than via automated PRs.
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
+      # Python is pinned deliberately (matched to the image base); bump manually.
       - dependency-name: "python"
+      # jupyter-book 2.x is a major rewrite — stay on 1.x until we opt in.
+      - dependency-name: "jupyter-book"
+        update-types: ["version-update:semver-major"]
 
   # ── Third-party GitHub Actions ─────────────────────────────────────────────
   # "/" covers .github/workflows/; for github-actions, composite actions in
@@ -50,7 +56,7 @@ updates:
       - "/publish-gh-pages"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - "maintenance"
     commit-message:
@@ -59,9 +65,15 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       # Don't propose bumps to our own internal sibling references (floating @v0).
       - dependency-name: "quantecon/actions*"
+    # NOTE: action major bumps (actions/checkout, actions/upload-artifact,
+    # docker/*, ...) are intentionally NOT ignored — they arrive as individual
+    # PRs to review one at a time.
 
   # ── Container base image ───────────────────────────────────────────────────
   # Tracks the `FROM ubuntu:24.04` base in each Dockerfile (not the Miniconda
@@ -72,7 +84,7 @@ updates:
       - "/containers/quantecon-build"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - "maintenance"
     commit-message:
@@ -81,3 +93,9 @@ updates:
       docker:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Stay on the 24.04 LTS base; bump deliberately when moving to the next LTS.
+      - dependency-name: "ubuntu"


### PR DESCRIPTION
Tames the Dependabot PR flood (currently 17: #49–#65) **without** losing per-update control over major bumps.

## Approach (revised after review)
Grouping *everything* was the wrong shape — a poison-pill major like `jupyter-book 2.x` would force you to either accept it (to take the safe updates) or reject the whole group. So instead:

- **Group only `minor`/`patch`** → one tidy PR per ecosystem (conda / github-actions / docker) for the low-risk noise (e.g. `quantecon-book-theme 0.18→0.21`, the `sphinx-*` bumps).
- **Majors arrive as individual PRs** → reviewed and accepted one at a time.
- **Hard-block what we already know is wrong**, via `ignore`:
  - `jupyter-book` **major** → stay on 1.x (2.x is a major rewrite).
  - `ubuntu` → stay on the **24.04 LTS** base until we deliberately move to the next LTS.
- GitHub Actions majors (`actions/checkout 4→6`, `actions/upload-artifact 4→7`, `docker/*`) are **not** ignored — they come as individual PRs for you to review.

## What happens on merge
Dependabot re-evaluates and:
- opens grouped minor/patch PRs and **closes the superseded individual ones**;
- **closes** the jupyter-book-2.x and ubuntu-26.04 PRs (now ignored);
- leaves the action-major PRs as individual PRs to review.

`open-pull-requests-limit` raised to 10 so the individual major PRs aren't suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)