### PR TITLE
setup-environment: fix standard-mode conda caching + validation (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the source/output directories passed via `env` and quoted, so paths with spaces/metacharacters are
   handled safely. The `output-dir` default changed from `./` to `.` (drops the `.//_build`
   double-slash). `extra-args` is still word-split (documented in the step). (#36, M10/L17/L22)
+- **setup-environment**: Fixed standard-mode (non-container) Conda caching — the env was restored
+  from cache and then **recreated unconditionally** by `setup-miniconda`, so the cache saved
+  nothing. It now restores the cached env (`${CONDA}/envs`) and only runs `conda env update` on a
+  cache miss; dropped the deprecated `use-only-tar-bz2`. Missing LaTeX requirements now error
+  instead of silently skipping (broken env later), and the `cache-version` input documents that it
+  is standard-mode only (no effect in container mode). (#33, C3/L19/L23)
 
 ### Changed
 - **restore-jupyter-cache**: Documented the optional `save-cache` input (PR-scoped saving) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   double-slash). `extra-args` is still word-split (documented in the step). (#36, M10/L17/L22)
 - **setup-environment**: Fixed standard-mode (non-container) Conda caching — the env was restored
   from cache and then **recreated unconditionally** by `setup-miniconda`, so the cache saved
-  nothing. It now restores the cached env (`${CONDA}/envs`) and only runs `conda env update` on a
-  cache miss; dropped the deprecated `use-only-tar-bz2`. Missing LaTeX requirements now error
-  instead of silently skipping (broken env later), and the `cache-version` input documents that it
-  is standard-mode only (no effect in container mode). (#33, C3/L19/L23)
+  nothing. It now restores the cached env (`${CONDA}/envs`, keyed by env name + Python version +
+  `environment.yml` hash) and runs `conda env update --prune` only when there's no exact cache hit
+  (a miss or a `restore-keys` partial match); dropped the deprecated `use-only-tar-bz2`. The
+  `environment.yml` is validated up front, missing LaTeX requirements now error instead of silently
+  skipping (broken env later), and the `cache-version` input documents that it is standard-mode only
+  (no effect in container mode). (#33, C3/L19/L23)
 
 ### Changed
 - **restore-jupyter-cache**: Documented the optional `save-cache` input (PR-scoped saving) and

--- a/setup-environment/action.yml
+++ b/setup-environment/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: 'quantecon'
   cache-version:
-    description: 'Cache version for manual invalidation (bump to force cache rebuild)'
+    description: 'Cache version for manual invalidation of the standard-mode Conda env cache (bump to force a rebuild). No effect in container mode, which uses the pre-installed environment and has no Conda cache.'
     required: false
     default: 'v1'
   install-latex:
@@ -96,30 +96,35 @@ runs:
     # NON-CONTAINER MODE: Full installation (existing behavior)
     # ============================================================
     
-    - name: Cache Conda Environment (non-container mode)
+    - name: Setup Miniconda (non-container mode)
+      if: steps.detect-container.outputs.container-mode == 'false'
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        # No environment-file here: the env is restored from cache (hit) or
+        # created by the "Create/update environment" step below (miss), so a
+        # cache hit is not wastefully rebuilt. Uses the runner's pre-installed
+        # conda (kept current by auto-update-conda) so the cached env lives at
+        # a stable ${CONDA}/envs path.
+        auto-update-conda: true
+        auto-activate-base: true
+        python-version: ${{ inputs.python-version }}
+        activate-environment: ${{ inputs.environment-name }}
+
+    - name: Cache Conda environment (non-container mode)
       if: steps.detect-container.outputs.container-mode == 'false'
       uses: actions/cache@v4
       id: conda-cache
       with:
-        path: |
-          /home/runner/miniconda3/envs/${{ inputs.environment-name }}
-          /home/runner/conda_pkgs_dir
+        path: ${{ env.CONDA }}/envs
         key: conda-${{ runner.os }}-${{ hashFiles(inputs.environment) }}-${{ inputs.cache-version }}
         restore-keys: |
           conda-${{ runner.os }}-${{ hashFiles(inputs.environment) }}-
           conda-${{ runner.os }}-
-    
-    - name: Setup Anaconda (non-container mode)
-      if: steps.detect-container.outputs.container-mode == 'false'
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        auto-update-conda: true
-        auto-activate-base: true
-        miniconda-version: 'latest'
-        python-version: ${{ inputs.python-version }}
-        environment-file: ${{ inputs.environment }}
-        activate-environment: ${{ inputs.environment-name }}
-        use-only-tar-bz2: true
+
+    - name: Create/update environment (non-container mode, cache miss)
+      if: steps.detect-container.outputs.container-mode == 'false' && steps.conda-cache.outputs.cache-hit != 'true'
+      shell: bash -l {0}
+      run: conda env update -n ${{ inputs.environment-name }} -f ${{ inputs.environment }}
 
     - name: Install LaTeX packages (non-container mode)
       if: steps.detect-container.outputs.container-mode == 'false' && inputs.install-latex == 'true'
@@ -132,8 +137,8 @@ runs:
           sudo apt-get update
           sudo apt-get install -y $PACKAGES
         else
-          echo "Warning: No latex-requirements.txt found at ${{ inputs.latex-requirements-file }}"
-          echo "Skipping LaTeX installation"
+          echo "::error::install-latex is true but no LaTeX requirements file was found at ${{ inputs.latex-requirements-file }}"
+          exit 1
         fi
 
     # ============================================================

--- a/setup-environment/action.yml
+++ b/setup-environment/action.yml
@@ -96,6 +96,15 @@ runs:
     # NON-CONTAINER MODE: Full installation (existing behavior)
     # ============================================================
     
+    - name: Validate environment file (non-container mode)
+      if: steps.detect-container.outputs.container-mode == 'false'
+      shell: bash
+      run: |
+        if [ ! -f "${{ inputs.environment }}" ]; then
+          echo "::error::Environment file not found: ${{ inputs.environment }} (required in standard / non-container mode)"
+          exit 1
+        fi
+
     - name: Setup Miniconda (non-container mode)
       if: steps.detect-container.outputs.container-mode == 'false'
       uses: conda-incubator/setup-miniconda@v3
@@ -116,15 +125,18 @@ runs:
       id: conda-cache
       with:
         path: ${{ env.CONDA }}/envs
-        key: conda-${{ runner.os }}-${{ hashFiles(inputs.environment) }}-${{ inputs.cache-version }}
+        key: conda-${{ runner.os }}-${{ inputs.environment-name }}-py${{ inputs.python-version }}-${{ hashFiles(inputs.environment) }}-${{ inputs.cache-version }}
         restore-keys: |
-          conda-${{ runner.os }}-${{ hashFiles(inputs.environment) }}-
-          conda-${{ runner.os }}-
+          conda-${{ runner.os }}-${{ inputs.environment-name }}-py${{ inputs.python-version }}-${{ hashFiles(inputs.environment) }}-
+          conda-${{ runner.os }}-${{ inputs.environment-name }}-py${{ inputs.python-version }}-
 
-    - name: Create/update environment (non-container mode, cache miss)
+    - name: Create/update environment (non-container mode, no exact cache hit)
       if: steps.detect-container.outputs.container-mode == 'false' && steps.conda-cache.outputs.cache-hit != 'true'
       shell: bash -l {0}
-      run: conda env update -n ${{ inputs.environment-name }} -f ${{ inputs.environment }}
+      # Runs on a true cache miss OR a restore-keys partial match (cache-hit is
+      # exact-only). --prune removes deps dropped from environment.yml when
+      # updating an older restored env.
+      run: conda env update -n ${{ inputs.environment-name }} -f ${{ inputs.environment }} --prune
 
     - name: Install LaTeX packages (non-container mode)
       if: steps.detect-container.outputs.container-mode == 'false' && inputs.install-latex == 'true'


### PR DESCRIPTION
Closes #33 (C3, L19, L23) — makes the non-container (standard-mode) Conda cache actually save time, plus two smaller hardening/doc fixes.

## C3 — the cache was a no-op
Before, standard mode restored the Conda cache **and then** ran `setup-miniconda` with `environment-file:` set, which **recreates the env every run** — so the cache never helped (the README's "~3-4 min cached" was aspirational).

Restructured to the [documented setup-miniconda caching recipe](https://github.com/conda-incubator/setup-miniconda#caching-environments):
1. `setup-miniconda` runs **without** `environment-file` (installs conda + the named env shell, doesn't rebuild from the file);
2. `actions/cache` restores the env at **`${CONDA}/envs`**;
3. a new step runs `conda env update` **only on a cache miss** (`cache-hit != 'true'`, which also covers prefix-matched restores when the env file changed).

Also:
- dropped the **deprecated `use-only-tar-bz2`**;
- dropped `miniconda-version: latest` so the env lives at a stable `${CONDA}/envs` path (the runner's pre-installed conda, kept current by `auto-update-conda`) — this is what makes the cache path reliable.

## L19 — fail loudly on missing LaTeX requirements
`install-latex: true` with a missing requirements file now **errors and exits** instead of warning + skipping (which produced an env that failed ~an hour later in the build).

## L23 — `cache-version` doc
Documented that `cache-version` only affects the standard-mode Conda cache (no effect in container mode, which has no Conda cache).

## ⚠️ Validation note
Standard mode is a **fallback** (the templates are container-first), and conda env caching is finicky and **can't be verified locally**. Worth confirming on a real CI run: the **second** run on an unchanged `environment.yml` should log a cache hit and **skip** the "Create/update environment" step. If the `${CONDA}/envs` path turns out wrong on the hosted runner, the fix is a one-line path tweak.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)