### PR TITLE
SHA-pin third-party GitHub Actions (#39)

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -32,10 +32,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/quantecon
           tags: |
@@ -51,7 +51,7 @@ jobs:
             type=sha,prefix={{branch}}-
 
       - name: Build and push quantecon container
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: containers/quantecon
           file: containers/quantecon/Dockerfile
@@ -73,10 +73,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/quantecon-build
           tags: |
@@ -92,7 +92,7 @@ jobs:
             type=sha,prefix={{branch}}-
 
       - name: Build and push quantecon-build container
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: containers/quantecon-build
           file: containers/quantecon-build/Dockerfile

--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -71,7 +71,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **preview-netlify / preview-cloudflare**: PR-controlled values (changed file paths, deploy URL)
   are now passed to the `github-script` PR-comment step via `env` and read from `process.env`
   instead of being interpolated into the script body, closing a script-injection vector. (#35, N2)
+- **CI**: SHA-pinned the third-party GitHub Actions (`docker/*`, `softprops/action-gh-release`,
+  `conda-incubator/setup-miniconda`) to full commit SHAs (with a `# vN` comment), so a hijacked
+  upstream tag can't inject code into our workflows. First-party `actions/*` stay on major tags
+  (GitHub-maintained, per GitHub's guidance), and Dependabot keeps the SHA pins current. (#39, L18)
 
 ### Documentation
 - Swept the docs for stale references and inconsistencies (#40, D24–D34): replaced dead workflow /

--- a/publish-gh-pages/action.yml
+++ b/publish-gh-pages/action.yml
@@ -144,7 +144,7 @@ runs:
     - name: Upload release assets
       id: upload-release
       if: inputs.create-release-assets == 'true' && steps.create-assets.outputs.assets-created == 'true'
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
       with:
         files: |
           ${{ steps.create-assets.outputs.archive-name }}

--- a/setup-environment/action.yml
+++ b/setup-environment/action.yml
@@ -107,7 +107,7 @@ runs:
 
     - name: Setup Miniconda (non-container mode)
       if: steps.detect-container.outputs.container-mode == 'false'
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
       with:
         # No environment-file here: the env is restored from cache (hit) or
         # created by the "Create/update environment" step below (miss), so a


### PR DESCRIPTION
Closes #39 (L18). Pins the **third-party** actions to full commit SHAs so a hijacked upstream tag can't inject code into our workflows (the threat demonstrated by the `tj-actions/changed-files` compromise — repointed tags dumped CI secrets). First-party `actions/*` are left on major tags per GitHub's own guidance, and **Dependabot keeps the SHA pins current** (it bumps the SHA + the `# vN` comment).

## Pinned (with `# vN` comment for readability)
| Action | Files | SHA = |
|--------|-------|-------|
| `docker/login-action` | build-containers, test-container | `c94ce9f…` # v3 |
| `docker/setup-buildx-action` | build-containers | `8d2750c…` # v3 |
| `docker/metadata-action` | build-containers | `c299e40…` # v5 |
| `docker/build-push-action` | build-containers | `ca052bb…` # v5 |
| `softprops/action-gh-release` | publish-gh-pages | `3bb1273…` # v2 |
| `conda-incubator/setup-miniconda` | setup-environment | `fc2d68f…` # v3 |

Each SHA is what the action's current major tag resolves to today.

## Left on major tags (intentional)
`actions/checkout`, `actions/cache`, `actions/upload-artifact`, `actions/github-script`, `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages` — GitHub-maintained; low hijack risk.

## ⚠️ Merge-order note
`conda-incubator/setup-miniconda` is in `setup-environment/action.yml`, which **open PR #78 (#33)** also edits. Whichever merges second needs a trivial one-line rebase (re-apply the SHA pin to that `uses:` line). Suggest merging #78 first, then I rebase this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)