### PR TITLE
Cap nodejs at the current LTS (node 24)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,9 @@ updates:
       # jupyter-book 2.x is a major rewrite — stay on 1.x until we opt in.
       - dependency-name: "jupyter-book"
         update-types: ["version-update:semver-major"]
+      # Cap node at the current LTS (24); don't propose the non-LTS 25+ lines.
+      - dependency-name: "nodejs"
+        versions: [">=25"]
 
   # ── Third-party GitHub Actions ─────────────────────────────────────────────
   # "/" covers .github/workflows/; for github-actions, composite actions in

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,11 @@
 version: 2
 updates:
   # ── Conda environments (container images) ──────────────────────────────────
-  # The conda ecosystem (GA Dec 2025) resolves Python packages via PyPI — it
-  # tracks the `pip:` block (jupyter-book, quantecon-book-theme, the sphinx-*
-  # extensions, kaleido) and Python conda deps. Conda-only entries such as the
-  # `anaconda` metapackage and `nodejs` are not on PyPI and won't be updated.
+  # The conda ecosystem (GA Dec 2025) tracks the `pip:` block (jupyter-book,
+  # quantecon-book-theme, the sphinx-* extensions, kaleido) via PyPI, and also
+  # proposes version-range bumps for conda deps such as `nodejs` — which is why
+  # it's capped in the ignore list below. The `anaconda` metapackage is pinned
+  # to a date version (`=2025.12`), so it stays put.
   - package-ecosystem: "conda"
     directories:
       - "/containers/quantecon"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Containers**: Pinned Miniconda in the full `quantecon` image to a specific version + SHA256
   (matching the lean `quantecon-build` image) for supply-chain security and reproducibility, and
   added `apt-get clean` for image-size parity. (#32, C2/L20)
+- **Containers**: Capped `nodejs` at the current LTS (`>=20,<25`, i.e. ≤ node 24) in both container
+  environments, and added a matching Dependabot `ignore` (node ≥ 25), so the non-LTS node 25 line
+  Dependabot's `<26` would have allowed is excluded.
 - **preview-netlify / preview-cloudflare**: De-duplicated the change-detection logic into a shared
   `scripts/detect-changed-lectures.sh`, and made it treat `lectures-dir` as a literal path instead
   of a regex (a dir name with `.`/`+` etc. no longer misbehaves). The per-file "has changes" test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (matching the lean `quantecon-build` image) for supply-chain security and reproducibility, and
   added `apt-get clean` for image-size parity. (#32, C2/L20)
 - **Containers**: Capped `nodejs` at the current LTS (`>=20,<25`, i.e. ≤ node 24) in both container
-  environments, and added a matching Dependabot `ignore` (node ≥ 25), so the non-LTS node 25 line
-  Dependabot's `<26` would have allowed is excluded.
+  environments, and added a matching Dependabot `ignore` (node ≥ 25), excluding the non-LTS node 25
+  line that Dependabot's `<26` proposal would have allowed.
 - **preview-netlify / preview-cloudflare**: De-duplicated the change-detection logic into a shared
   `scripts/detect-changed-lectures.sh`, and made it treat `lectures-dir` as a literal path instead
   of a regex (a dir name with `.`/`+` etc. no longer misbehaves). The per-file "has changes" test

--- a/containers/quantecon-build/environment.yml
+++ b/containers/quantecon-build/environment.yml
@@ -50,7 +50,7 @@ dependencies:
   - pyyaml
   
   # Build tools
-  - nodejs>=20,<21  # Required for some Jupyter extensions
+  - nodejs>=20,<25  # Jupyter extensions; capped at node 24 LTS (exclude non-LTS 25)
   
   - pip
   - pip:

--- a/containers/quantecon/environment.yml
+++ b/containers/quantecon/environment.yml
@@ -9,7 +9,7 @@ channels:
 dependencies:
   - python=3.13
   - anaconda=2025.12  # Full Anaconda: numpy, scipy, pandas, matplotlib, seaborn, sympy, jupyter, jupyterlab, ipywidgets, networkx, statsmodels, numba, and 400+ more
-  - nodejs>=20,<21    # Required for netlify-cli in preview-netlify action (matches jupyterlab requirement)
+  - nodejs>=20,<25    # netlify-cli (preview-netlify) + jupyterlab; capped at node 24 LTS (exclude non-LTS 25)
   - pip
   - pip:
     # Jupyter Book build tools


### PR DESCRIPTION
Resolves the nodejs Dependabot PRs (#58, #65) deliberately rather than merging their over-wide bump.

## Why
Dependabot proposed `nodejs>=20,<21` → `>=20,<26`, which would allow **node 25** — a **non-LTS** line that netlify-cli / jupyterlab don't reliably support. But the current `<21` pin (node 20) is also at the end of its LTS window.

## What
- Set **`nodejs>=20,<25`** (≤ **node 24**, the current LTS) in both `containers/quantecon/environment.yml` and `containers/quantecon-build/environment.yml`.
- Added a Dependabot **`ignore`** for `nodejs` `>=25`, so it won't re-propose the `<26` widening every week.

Net: the build can move up to node 24 LTS, the non-LTS 25 line is excluded, and Dependabot stays quiet on node.

Closes #58, closes #65 (superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)