### PR TITLE
Release v0.8.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -130,7 +130,7 @@ gh run view RUN_ID --log > /tmp/gh-logs.txt && cat /tmp/gh-logs.txt
 
 - **Created:** November 2025
 - **Updated:** June 16, 2026
-- **Current Phase:** Infrastructure complete, ready for production migration (latest release: v0.7.0)
+- **Current Phase:** Infrastructure complete, ready for production migration (latest release: v0.8.0)
 - **Containers:** ghcr.io/quantecon/quantecon:latest (full, ~8GB), ghcr.io/quantecon/quantecon-build:latest (lean, ~3GB)
 - **Actions:** 7 composite actions complete and tested
 - **Next:** Begin Phase 1 migration with lecture-dp repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-16
+
 ### Fixed
 - **restore-jupyter-cache**: Read-only restore no longer uses a fake `-00000000` primary key that
   could never match; it now uses the content/env prefix directly, so the logged "Requested Key" is
@@ -306,7 +308,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version History
 
-- **v0**: Tracks latest stable release (currently v0.1.1)
+- **v0**: Tracks latest stable release (currently v0.8.0)
 - **v0.x.x**: Development/testing releases
 
 ## Migration from Legacy Workflows

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Reusable composite GitHub Actions for building QuantEcon lecture repositories.
 
 This repository provides a set of composite actions that standardize and optimize the build process for QuantEcon lecture websites. These actions include intelligent caching strategies that significantly reduce build times.
 
-**Status:** Stable; current release `v0.7.0` (see the [CHANGELOG](./CHANGELOG.md)).
+**Status:** Stable; current release `v0.8.0` (see the [CHANGELOG](./CHANGELOG.md)).
 
 📋 **See:** [docs/CONTAINER-GUIDE.md](./docs/CONTAINER-GUIDE.md) for quick start, [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for design overview.
 
@@ -172,7 +172,7 @@ The lecture repositories that consume these actions are tracked centrally in [Qu
 We're in the `0.x` development phase (pre-1.0.0). Reference the actions with:
 
 - `@v0` - Latest `0.x` release (recommended; floating tag, moved to each new release)
-- `@v0.7.0` - Specific version (maximum reproducibility)
+- `@v0.8.0` - Specific version (maximum reproducibility)
 - `@main` - Latest development (use for testing only)
 
 > ⚠️ During `0.x`, minor releases (`0.x.0`) may include breaking changes, so the floating


### PR DESCRIPTION
Cuts **v0.8.0**, rolling up everything merged since v0.7.0 (`main` is +17 commits; the floating `@v0` tag is still frozen at v0.7.0, so none of this is live for consumers yet).

## What's in it
- **Fixed** — standard-mode conda caching now actually caches (env was being recreated unconditionally); container-test workflows check out the built SHA; internal sibling calls pinned `@main`→`@v0`; `publish-gh-pages` release-asset tag/token guards; `build-lectures` drops `eval` and quotes path inputs (`output-dir` default `./`→`.`).
- **Changed** — Miniconda pinned + SHA256 in the full image; `nodejs` capped at the current LTS (≤24); preview actions share `detect-changed-lectures.sh`; Dependabot config added (grouped per ecosystem).
- **Security** — preview actions read PR-controlled values from `process.env` (closes a script-injection vector); third-party actions (`docker/*`, `softprops/action-gh-release`, `conda-incubator/setup-miniconda`) SHA-pinned.
- **Documentation** — the D24–D34 stale-reference sweep.

See the [CHANGELOG](./CHANGELOG.md) `[0.8.0]` section for the full list.

## Release mechanics
This PR only bumps the version mentions (CHANGELOG `[Unreleased]`→`[0.8.0]`, README, copilot-instructions). After merge: create the **v0.8.0** GitHub release and move the floating `v0` tag to it (`git tag -f v0 "v0.8.0^{}"` + force-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)