### PR TITLE
Pin lean container's science stack to the Anaconda 2025.12 baseline (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Containers (quantecon-build)**: Pinned the lean image's core scientific stack (numpy, scipy,
+  pandas, matplotlib, seaborn, sympy, numba, networkx, statsmodels, scikit-learn) to the Anaconda
+  2025.12 baseline that every lecture repo builds against (via `anaconda=2025.12`), instead of
+  resolving to "latest at build time". The unpinned stack drifted ahead of that baseline, yielding
+  non-reproducible images that diverged from what the lectures are tested against; downstream this
+  surfaced as a `CellExecutionError` in `un_insure.md` on repos building on the lean image (the
+  likely trigger being numpy 2.4.0's stricter array-to-scalar conversion, though the exact breaking
+  combination is no longer reproducible on current packages). The full `quantecon` image already
+  pins `anaconda=2025.12` and was unaffected. (#28)
+
 ## [0.8.0] - 2026-06-16
 
 ### Fixed

--- a/containers/quantecon-build/README.md
+++ b/containers/quantecon-build/README.md
@@ -23,7 +23,8 @@ ghcr.io/quantecon/quantecon-build:latest
 
 ### Python Packages (Superset for all QuantEcon lectures)
 
-Core scientific stack:
+Core scientific stack (pinned to the Anaconda 2025.12 baseline, matching the
+versions the lecture repos build against):
 - numpy, scipy, pandas, matplotlib, seaborn
 - sympy, numba, networkx, statsmodels
 - jupyter, jupyterlab, ipywidgets
@@ -78,7 +79,7 @@ docker pull ghcr.io/quantecon/quantecon:latest
 | Size | ~8GB | ~3GB |
 | Pull time | ~2-3 min | ~1 min |
 | Packages | ~450 | ~100 |
-| Anaconda | Full 2025.12 | Explicit list |
+| Anaconda | Full 2025.12 | Explicit list (science stack pinned to 2025.12) |
 | TexLive | Full | Minimal |
 | Best for | Development | CI/CD |
 

--- a/containers/quantecon-build/environment.yml
+++ b/containers/quantecon-build/environment.yml
@@ -9,17 +9,23 @@ dependencies:
   # Python
   - python=3.13
   
-  # Core scientific stack (used by most lectures)
-  - numpy
-  - scipy
-  - pandas
-  - matplotlib
-  - seaborn
-  - sympy
-  - numba
-  - networkx
-  - statsmodels
-  - scikit-learn
+  # Core scientific stack — pinned to the Anaconda 2025.12 baseline that every
+  # QuantEcon lecture repo builds against (they pin `anaconda=2025.12`), keeping
+  # this lean image reproducible and consistent with the full `quantecon` image
+  # and the source repos. Left unpinned, the stack drifted ahead of that baseline
+  # and produced non-reproducible images that broke notebook execution downstream
+  # (e.g. un_insure.md's fsolve call; see #28).
+  # Bump as a set when the lecture repos move to a newer anaconda release.
+  - numpy=2.3.5
+  - scipy=1.16.3
+  - pandas=2.3.3
+  - matplotlib=3.10.6
+  - seaborn=0.13.2
+  - sympy=1.14.0
+  - numba=0.62.1
+  - networkx=3.5
+  - statsmodels=0.14.5
+  - scikit-learn=1.7.2
   
   # CPU acceleration (Intel MKL for optimized linear algebra)
   - mkl


### PR DESCRIPTION
Closes #28.

## Root cause

The `quantecon-build` (lean) image listed its scientific stack **unpinned**, so numpy/scipy/pandas/etc. resolved to *latest at build time* and **drifted ahead of the Anaconda 2025.12 set** that every lecture repo pins via `anaconda=2025.12` (and that the full `quantecon` image uses). That drift produced non-reproducible images that diverged from what the lectures are tested against, and surfaced downstream as a `CellExecutionError` in `un_insure.md`'s `sp.optimize.fsolve(Vu_error_Λ, 15000, ...)` path for repos that build on the lean image (e.g. lecture-dp). The full image already pins `anaconda=2025.12` and was unaffected.

## Fix

Pin the lean image's core scientific stack to the **exact Anaconda 2025.12 versions**, so the lean image stays reproducible and consistent with the full image and the source repos.

| package | was | now (= Anaconda 2025.12) |
|---|---|---|
| numpy | unpinned | 2.3.5 |
| scipy | unpinned | 1.16.3 |
| pandas | unpinned | 2.3.3 |
| matplotlib | unpinned | 3.10.6 |
| seaborn | unpinned | 0.13.2 |
| sympy | unpinned | 1.14.0 |
| numba | unpinned | 0.62.1 |
| networkx | unpinned | 3.5 |
| statsmodels | unpinned | 0.14.5 |
| scikit-learn | unpinned | 1.7.2 |

Pinning the whole core stack (not just numpy/scipy) eliminates the drift class entirely and keeps numba/numpy in their tested pairing. Dependabot (conda ecosystem) will surface future bumps for review; bump the set when the lecture repos move to a newer Anaconda release.

## On the exact breakage — honest caveat

I could **not** reproduce the original `un_insure.md` failure on current packages. The actual calibration cell runs cleanly on **four** combinations I tested — numpy 2.3.5+scipy 1.16.3 (2025.12), numpy 2.4.0+scipy 1.15.3, numpy 2.4.0+scipy 1.16.3, and numpy 2.4.6+scipy 1.17.1 (2026.06). numpy 2.4.0 *did* make `float()`/`int()` of a 1-d array a hard `TypeError`, which is the most likely trigger class, but the specific combination that broke it in March 2026 appears to have been a transient regression that's since been patched upstream. The fix here stands regardless: it addresses the **root cause** (unpinned drift / non-reproducible builds that diverge from the source-repo baseline), not the transient trigger.

## Why not Anaconda 2026.06

2026.06 exists and is installable for py313, and `un_insure.md` does run on its stack (numpy 2.4.6 / scipy 1.17.1). But it jumps to **pandas 3.0** (a major release no lecture repo is validated against) and would make the containers **diverge from the source repos** (all still on 2025.12), recreating the drift this PR fixes. The newer baseline should be a separate, coordinated bump of the lecture repos + both containers.

## Verification

- Confirmed the pinned set solves on `linux-64` (the container platform) via `conda env create --dry-run` with `CONDA_OVERRIDE_GLIBC=2.39`; numpy resolves to 2.3.5, numba to 0.62.1, nodejs stays at 20.x (within `>=20,<25`).
- Version data taken directly from `conda search anaconda=2025.12=py313_mkl_0 --info` against `pkgs/main`.
- Ran the actual `un_insure.md` calibration cell (extracted helpers + brentq→fsolve) on the pinned baseline and on the current-latest stack.

## Notes for reviewers

- **Testing does cover this.** `test-containers-lectures.yml` runs after each container build (`workflow_run`) and its Stage 1 "Build HTML (Execute Notebooks)" executes notebooks for `lecture-python-advanced.myst` (which contains `un_insure.md`) on both images. Caveat: that workflow is non-blocking (runs after `:latest` is pushed) and has been red for months.
- **Separate pre-existing breakage (not addressed here):** the container tests are *currently* failing on a `ChromeNotFoundError` from `kaleido` v1 (unpinned) on Plotly static-image export (`BCG_complete_mkts.md`, `BCG_incomplete_mkts.md`, `knowing_forecasts_of_others.md`) — a distinct "unpinned dep bumped a major" problem worth its own issue/PR. The container test signal won't go fully green until that's fixed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)