### PR TITLE
Pin kaleido<1.0 in both containers to fix ChromeNotFoundError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   likely trigger being numpy 2.4.0's stricter array-to-scalar conversion, though the exact breaking
   combination is no longer reproducible on current packages). The full `quantecon` image already
   pins `anaconda=2025.12` and was unaffected. (#28)
+- **Containers**: Pinned `kaleido<1.0` in both images and dropped the build-time
+  `kaleido.get_chrome_sync()` step. Unpinned, `kaleido` resolved to v1.x, which dropped the bundled
+  chromium and requires a separately provisioned Chrome; the build-time download landed in `/root`
+  but CI container jobs run with `HOME=/github/home`, so Plotly static-image export failed at runtime
+  with `ChromeNotFoundError` (e.g. `BCG_complete_mkts.md`, `BCG_incomplete_mkts.md`,
+  `knowing_forecasts_of_others.md`). kaleido 0.2.x bundles its own chromium (location-independent)
+  and still exports PNGs on the current plotly. (Migrating to kaleido v1 with system-provisioned
+  Chrome is a future follow-up.)
 
 ## [0.8.0] - 2026-06-16
 

--- a/containers/quantecon-build/Dockerfile
+++ b/containers/quantecon-build/Dockerfile
@@ -84,8 +84,6 @@ ENV PATH=$CONDA_DIR/bin:$PATH
 COPY environment.yml /tmp/environment.yml
 RUN conda tos accept && \
     conda env create -f /tmp/environment.yml && \
-    # Install Chrome for kaleido (Plotly static image export)
-    /opt/conda/envs/quantecon/bin/python -c "import kaleido; kaleido.get_chrome_sync()" && \
     # Aggressive cleanup to reduce size
     conda clean -afy && \
     find /opt/conda -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true && \

--- a/containers/quantecon-build/environment.yml
+++ b/containers/quantecon-build/environment.yml
@@ -73,5 +73,9 @@ dependencies:
     - quantecon-book-networks
     
     # Additional build dependencies
-    - kaleido  # Plotly static image export
+    # Pinned <1.0: kaleido v1 dropped the bundled chromium and needs a separately
+    # provisioned Chrome, which isn't found at runtime in CI (container jobs set
+    # HOME=/github/home, not the build-time /root). v0.2.x bundles its own
+    # chromium (location-independent) and still works with current plotly. (#28-class)
+    - kaleido<1.0  # Plotly static image export
     - prettytable

--- a/containers/quantecon/Dockerfile
+++ b/containers/quantecon/Dockerfile
@@ -88,8 +88,6 @@ ENV PATH=$CONDA_DIR/bin:$PATH
 COPY environment.yml /tmp/environment.yml
 RUN conda tos accept && \
     conda env create -f /tmp/environment.yml && \
-    # Install Chrome for kaleido (Plotly static image export)
-    /opt/conda/envs/quantecon/bin/python -c "import kaleido; kaleido.get_chrome_sync()" && \
     conda clean -afy && \
     rm /tmp/environment.yml
 

--- a/containers/quantecon/environment.yml
+++ b/containers/quantecon/environment.yml
@@ -23,4 +23,8 @@ dependencies:
     - sphinx-togglebutton==0.4.5
     - sphinx-reredirects==1.1.0
     - quantecon-book-networks
-    - kaleido  # Plotly static image export
+    # Pinned <1.0: kaleido v1 dropped the bundled chromium and needs a separately
+    # provisioned Chrome, which isn't found at runtime in CI (container jobs set
+    # HOME=/github/home, not the build-time /root). v0.2.x bundles its own
+    # chromium (location-independent) and still works with current plotly. (#28-class)
+    - kaleido<1.0  # Plotly static image export


### PR DESCRIPTION
## Problem

The container tests (`test-containers-lectures.yml`) fail at notebook execution with `ChromeNotFoundError` from `kaleido` on Plotly static-image export — `BCG_complete_mkts.md`, `BCG_incomplete_mkts.md`, `knowing_forecasts_of_others.md`. This is the same "unpinned dependency bumped a major" class as #28.

## Root cause

`kaleido` was pip-installed **unpinned** and resolved to **v1.x** (currently 1.3.0). kaleido v1 dropped the self-contained chromium and requires a separately provisioned Chrome. Both Dockerfiles ran `kaleido.get_chrome_sync()` at build time — but that downloads Chrome under `/root/.cache` (build runs as root), while GitHub Actions **container jobs run with `HOME=/github/home`**, so at test runtime kaleido looks in the wrong place and can't find Chrome.

## Fix

- Pin **`kaleido<1.0`** in both `containers/quantecon/environment.yml` and `containers/quantecon-build/environment.yml`.
- Drop the now-invalid `kaleido.get_chrome_sync()` build step from both Dockerfiles (v0 has no such API; leaving it would fail the build).

kaleido 0.2.x bundles its own chromium **inside the package** (location-independent, so the `HOME` difference is irrelevant) and still exports images on the current plotly. The existing apt chromium runtime libs (`libnss3`, `libgbm1`, `libasound2t64`, …) are retained for the bundled browser.

## Verification

Installed `plotly==6.7.0` (the version the lean image resolves) + `kaleido==0.2.1` on Python 3.13 and exported a PNG:

```
plotly 6.7.0 | kaleido 0.2.1
to_image(engine=kaleido) OK -> 23957 bytes
```

Only `DeprecationWarning`s are emitted (Plotly notes kaleido v0 support is deprecated) — no error. The full image's plotly 6.3.0 is older and on the same deprecation (warn, not error) path.

## Caveat / follow-up

This is a pragmatic stopgap consistent with long-standing QuantEcon practice: kaleido v0 is deprecated by Plotly, so a future Plotly release could eventually drop it. **Migrating to kaleido v1 with a system-provisioned Chrome** (install `google-chrome`/`chromium` to a fixed path and point kaleido at it via env, independent of `HOME`) is the durable path and is left as a follow-up.

## Notes

- Separate from and complementary to #84 (which pinned the science stack). With both merged, the container test workflow should go green.
- The `ubuntu:24.04` base-image "high vulnerability" warning surfaced by the IDE is pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)