### PR TITLE
Rewrite PLAN.md as the repo's working plan (July 2026)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,205 +1,124 @@
-# Migration Plan
+# Plan
 
-Plan for migrating the 4 QuantEcon lecture repositories to use centralized composite actions.
+Working plan for `QuantEcon/actions`: current state, prioritized backlog, dependency policy, and rollout status.
 
-**Last Updated:** February 2026
-
----
-
-## Current State
-
-The core infrastructure is complete and validated:
-
-- **Container images** — `quantecon` (full, ~8GB) and `quantecon-build` (lean, ~3GB), validated against all 4 lecture repos
-- **Composite actions** — `setup-environment`, `build-lectures`, `build-jupyter-cache`, `restore-jupyter-cache`, `preview-netlify`, `preview-cloudflare`, `publish-gh-pages`
-- **Container-aware setup** — Auto-detects QuantEcon containers and RunsOn custom AMIs via `/etc/quantecon-container` marker
-- **Two-layer caching** — Container image (Layer 1) + dedicated cache actions for `_build/` directory (Layer 2), including PR-scoped caching
-- **Asset assembly** — PDF and notebook staging for HTML download features
-- **Execution reports** — Failure artifacts with reports and cache for debugging
-- **Multi-format builds** — HTML, pdflatex, and jupyter builders
-- **PR previews** — Netlify and Cloudflare Pages with smart PR comments
-- **GitHub Pages publishing** — Native OIDC-based deployment
+**Last updated:** July 2026 — after the v0.8.0 release and a deep technical review of all actions, containers, workflows, docs, and open issues/PRs.
 
 ---
 
-## Rollout Strategy
+## Current state
 
-### Phase 1: Production Test with `lecture-dp` (new repo)
+The core infrastructure is complete, hardened, and in production:
 
-Before migrating any existing repositories, we'll validate the full workflow on a **new** lecture series `lecture-dp`. This gives us a fresh canvas — no legacy workflows to work around, no risk to existing production sites, and a clean baseline for performance measurement.
+- **Actions (7)** — `setup-environment`, `build-lectures`, `build-jupyter-cache`, `restore-jupyter-cache`, `preview-netlify`, `preview-cloudflare`, `publish-gh-pages`; released at `v0.8.0`
+- **Containers (2)** — `quantecon` (full) and `quantecon-build` (lean); science stack pinned as a set to the Anaconda 2025.12 baseline (#28, #84), `kaleido<1.0` (#85), Miniconda SHA-pinned (#32)
+- **June 2026 hardening pass** — third-party actions SHA-pinned (#39, #79), shell safety in `build-lectures` (#36), preview actions de-duplicated and injection-hardened (#35), standard-mode conda caching fixed (#33, #78), docs sweep (#40, #66)
 
-| Step | Task | Status |
-|------|------|--------|
-| 1 | Create `lecture-dp` repo with standard lecture structure | ⏳ |
-| 2 | Set up container-based CI with `setup-environment` + `build-lectures` | ⏳ |
-| 3 | Add `build-jupyter-cache` / `restore-jupyter-cache` for caching | ⏳ |
-| 4 | Configure PR previews (`preview-netlify` or `preview-cloudflare`) | ⏳ |
-| 5 | Configure production deployment (`publish-gh-pages`) | ⏳ |
-| 6 | Run in production for a period, measure performance, gather feedback | ⏳ |
+**Known gap:** container-mode cache-build failure alerting is broken in the default configuration (#83) — this is the P0 item below.
 
-### Phase 2: Migrate Existing Repos
+### Consumers in production
 
-Once `lecture-dp` is running smoothly, migrate existing repos — CPU-only first, GPU last:
+| Repo | Actions used | Version |
+|---|---|---|
+| `lecture-dp` | Full chain: `restore-jupyter-cache`, `build-lectures`, `build-jupyter-cache`, `publish-gh-pages` | `@v0.8.0` |
+| `lecture-python.myst` | `preview-netlify` (ci.yml) | `@v0.8.0` |
+| `test-lecture-python-intro` | Full chain (test harness) | `@v0.6.0` |
 
-| # | Repository | Runner | Deployment | Complexity | Status |
-|---|-----------|--------|------------|------------|--------|
-| 1 | `lecture-python-intro` | Container | Netlify | Standard | ⏳ Planned |
-| 2 | `lecture-python-programming.myst` | Container | GitHub Pages | Standard | ⏳ Planned |
-| 3 | `lecture-python-advanced.myst` | Container | GitHub Pages | Standard | ⏳ Planned |
-| 4 | `lecture-python.myst` | RunsOn GPU | GitHub Pages | GPU + ML libs | ⏳ Planned |
-
-### Per-repo Migration Checklist
-
-- [ ] Create migration branch
-- [ ] Replace environment setup with `setup-environment`
-- [ ] Replace build steps with `build-lectures`
-- [ ] Add `build-jupyter-cache` / `restore-jupyter-cache` for build caching
-- [ ] Configure PR preview deployment (`preview-netlify` or `preview-cloudflare`)
-- [ ] Configure production deployment (`publish-gh-pages` or Netlify production)
-- [ ] Validate build output matches current production
-- [ ] Measure performance improvement
-- [ ] Merge and monitor
+Consumer/migration tracking lives in [QuantEcon/meta#321](https://github.com/QuantEcon/meta/issues/321); the preview-unification rollout is planned in [QuantEcon/meta#327](https://github.com/QuantEcon/meta/issues/327).
 
 ---
 
-## lecture-python.myst Gap Analysis
+## Backlog (July 2026 review)
 
-`lecture-python.myst` is the most complex repo — GPU builds, ML libraries, 3 build formats, release assets, and notebook sync. This section tracks what our actions already support and what needs work before we can migrate it.
+### P0 — broken safety net
 
-### Current Workflows (5)
+| # | Item | Refs |
+|---|---|---|
+| 1 | **Fix container-mode failure alerting.** Neither container image installs the `gh` CLI, so `create-failure-issue.sh` exits 127 when the cache build runs inside a container (the documented default) — every failure goes un-alerted. Install `gh` in both images, or fall back to the REST API via `curl`, and guard the script so a missing CLI is a loud `::error::`. Add a container test asserting `gh` is on PATH. | #83 |
 
-| Workflow | Trigger | Runner | Purpose |
-|----------|---------|--------|---------|
-| `cache.yml` | Weekly + manual | RunsOn `g4dn.2xlarge` GPU | Full HTML build, upload `_build` as artifact |
-| `ci.yml` | PR + manual | RunsOn `g4dn.2xlarge` GPU | Notebooks + PDF + HTML → Netlify preview |
-| `publish.yml` | Tag `publish*` | RunsOn `g4dn.2xlarge` GPU | PDF + notebooks + HTML → GH Pages + release + notebook sync |
-| `collab.yml` | Weekly + manual | RunsOn GPU + Colab container | Colab compatibility testing → issue on failure |
-| `linkcheck.yml` | Weekly + manual | `ubuntu-latest` | Link checker → issue on failure |
+### P1 — correctness and drift prevention
 
-### Key Architecture Patterns
+| # | Item | Refs |
+|---|---|---|
+| 2 | **Targeted execution reports on cache failure.** The build steps inside `build-jupyter-cache` don't pass `upload-failure-reports` (defaults `false`), so a failed cache build uploads no `reports/*.err.log` artifact while the auto-issue body tells maintainers to download one. Pass it through (default `true`) and align the issue-body text with the artifact actually produced. | #83 |
+| 3 | **Fix Dependabot conda grouping.** The conda groups match `*` with no `ignore` for the pinned science stack or `anaconda`, so Dependabot proposes exactly the drift the #28 pins exist to prevent (live proof: PRs #86, #87). Add `ignore` entries so the stack moves manually as a set, and correct the stale header comment. | #28, PRs #86/#87 |
+| 4 | **Hold PRs #86 and #87.** Both drift the container science stack off the 2025.12 baseline; #87 additionally pulls in pandas 3.0 (major, copy-on-write default). Handle container-stack bumps as one coordinated, validated move when the lecture repos adopt a new anaconda baseline (see Dependency policy). | #28 |
+| 5 | **`preview-cloudflare`: use the stable `pr-N` alias URL.** The PR comment currently shows the per-deployment hash URL grepped from wrangler output; construct `https://{branch-alias}.{project}.pages.dev` directly (the alias is already computed). | #14 |
 
-1. **Cache-first** — `cache.yml` runs weekly, uploads `_build` as artifact. CI/publish download it via `dawidd6/action-download-artifact@v12`
-2. **RunsOn GPU** — 4 of 5 workflows use `g4dn.2xlarge` with custom `quantecon_ubuntu2404` AMI
-3. **No conda caching** — Fresh `conda-incubator/setup-miniconda@v3` each run; build cache is the primary time saver
-4. **JAX CUDA** — Installed separately via `pip install -U "jax[cuda13]"` + `numpyro`, validated with `scripts/test-jax-install.py` and `nvidia-smi`
-5. **3 build passes** — `ci.yml` and `publish.yml` run: (1) jupyter notebooks, (2) pdflatex, (3) HTML
-6. **GH Pages via branch push** — `publish.yml` uses `peaceiris/actions-gh-pages@v4` (pushes to gh-pages branch)
+### P2 — surplus removal and quality
 
-### Feature Support Matrix
+| # | Item | Refs |
+|---|---|---|
+| 6 | **Extract the shared PR-comment script.** The 87-line `github-script` comment renderer is near-identical (only 2 lines differ) across `preview-netlify` and `preview-cloudflare`; move it to a shared script parameterized by title/emoji, as `detect-changed-lectures.sh` already is. | — |
+| 7 | **Delete the dead `asset-url` output** in `publish-gh-pages` — it is wired to an output `action-gh-release` doesn't expose, is always empty, and has no consumers. Remove the README row too. | — |
+| 8 | **`preview-netlify`: move the auth token into `env:`.** `--auth="…"` puts the secret on the process command line; the Cloudflare action already does this correctly. | — |
+| 9 | **CI coverage for standard-mode conda caching.** The only workflow exercising `setup-environment` runs in a container, so the #33/#78 cache fix has never been confirmed by CI. Add a two-run smoke test asserting a cache hit on the second run — this doubles as the seed of the #29 env-test harness. | #29, #33 |
+| 10 | **Docs surplus trim.** ~4,900 doc lines for ~1,600 lines of action code, with four overlapping indexes. Delete `docs/README.md`; shrink `QUICK-REFERENCE.md` to a one-screen link table; keep per-repo notes in one place (MIGRATION-GUIDE); drop the copilot-instructions "GitHub CLI Tool Constraints" section (boilerplate imported from another environment); strip the stale schedule/perf blocks from ARCHITECTURE.md; relocate `GPU-AMI-SETUP.md` to the infra/meta repo or trim it to the essentials (it documents AMI infrastructure — no workflow in this repo runs on GPU). Propagate corrected container-size figures everywhere. | #40 |
+| 11 | **Document composite action vs reusable workflow.** Add the short decision rule to CONTRIBUTING.md or ARCHITECTURE.md so new CI lands at the right altitude. | #29 |
+| 12 | **Environment manifest v1.** The publish-time manifest is a stub (name/tag/commit/size). Define a versioned schema, capture the effective environment (resolved `conda list`/`pip freeze`, container digest, build metadata), and `repository_dispatch` to `status-lectures`. | #30, meta#321 |
 
-| Feature | lecture-python.myst does | Our action | Status |
-|---------|-------------------------|------------|--------|
-| Environment setup on RunsOn AMI | `conda-incubator/setup-miniconda@v3` | `setup-environment` (marker detection) | ✅ Supported |
-| ML libs (JAX CUDA 13, numpyro) | `pip install -U "jax[cuda13]"` + numpyro | Repo's `environment.yml` / `environment-update.yml` | ✅ Repos manage their own ML packages |
-| HTML build | `jb build lectures -W --keep-going` | `build-lectures` (builder: html) | ✅ Supported |
-| PDF build | `jb build --builder pdflatex` | `build-lectures` (builder: pdflatex) | ✅ Supported |
-| Jupyter notebook build | `jb build --builder=custom --custom-builder=jupyter` | `build-lectures` (builder: jupyter) | ✅ Supported |
-| Asset staging (PDF → html/_pdf) | Manual `mkdir -p` + `cp` | `build-lectures` (`html-copy-pdf`) | ✅ Supported |
-| Asset staging (notebooks → html/_notebooks) | Manual `mkdir -p` + `cp` | `build-lectures` (`html-copy-notebooks`) | ✅ Supported |
-| Execution reports on failure | `actions/upload-artifact@v6` per builder | `build-lectures` (`upload-failure-reports`) | ✅ Supported |
-| Build cache (weekly generation) | Artifact upload via `actions/upload-artifact@v6` | `build-jupyter-cache` (uses `actions/cache`) | ✅ Supported — different mechanism |
-| Build cache (PR restore) | `dawidd6/action-download-artifact@v12` | `restore-jupyter-cache` (uses `actions/cache`) | ✅ Supported — different mechanism |
-| Netlify PR preview | Manual `netlify-cli` install + deploy | `preview-netlify` | ✅ Supported |
-| Changed file detection in PR | Custom bash git diff script | `preview-netlify` / `preview-cloudflare` | ✅ Supported |
-| GitHub Pages publish | `peaceiris/actions-gh-pages@v4` | `publish-gh-pages` (native OIDC) | ✅ Supported — different mechanism |
-| CNAME for custom domain | `cname: python.quantecon.org` | `publish-gh-pages` (`cname` input) | ✅ Supported |
-| Release assets (tar.gz + checksum + manifest) | `softprops/action-gh-release@v2` | `publish-gh-pages` (release asset inputs) | ✅ Supported |
-| Issue creation on failure | `peter-evans/create-issue-from-file@v6` | `build-jupyter-cache` (`create-issue-on-failure`) | ✅ Supported |
-| Download notebooks zip | `zip -r download-notebooks.zip _build/jupyter` | Inline workflow step | ⚪ Optional (for release assets) |
-| Notebook repo sync | Clone + push to `lecture-python.notebooks` | — | ⚪ Can be eliminated (notebooks on gh-pages) |
-| Colab compatibility testing | Separate workflow with Colab container | — | ⚪ Out of scope (standalone) |
-| Link checking | `lycheeverse/lychee-action@v2` | — | ⚪ Out of scope (standalone) |
-| GPU validation (`nvidia-smi`) | Inline step | — | ⚪ Inline step (no action needed) |
+### P3 — housekeeping
 
-### Items to Resolve
-
-#### 1. Verify `actions/cache` on RunsOn AMI
-
-**Priority:** High — blocking
-
-Our cache actions (`build-jupyter-cache`, `restore-jupyter-cache`) use `actions/cache`. The current `lecture-python.myst` uses artifact-based caching (`actions/upload-artifact` + `dawidd6/action-download-artifact`). We need to confirm `actions/cache` works correctly on RunsOn self-hosted runners.
-
-**Expected:** Should work — RunsOn runners are standard GitHub Actions runners with full API access. The `setup-environment` README already documents RunsOn + `actions/cache` compatibility.
-
-**Action:** Test with a simple workflow on a RunsOn runner.
-
-#### 2. Verify OIDC GitHub Pages deployment from RunsOn
-
-**Priority:** High — blocking
-
-Our `publish-gh-pages` uses native OIDC-based deployment (`actions/deploy-pages`). The current repo uses `peaceiris/actions-gh-pages@v4` which pushes to a gh-pages branch. OIDC deployment requires the runner to request an OIDC token from GitHub.
-
-**Expected:** Should work — RunsOn runners support OIDC tokens. But needs verification.
-
-**Action:** Test a Pages deployment from a RunsOn runner.
-
-#### 3. ~~Download Notebooks Zip~~ ✅ Resolved
-
-**Decision:** Inline workflow step (not needed as action feature)
-
-Simple one-liner for release assets if needed. Most users download individual notebooks from lecture pages, not bulk zips.
-
-#### 4. ~~Notebook Repository Sync~~ ✅ Architectural Decision
-
-**Decision:** Eliminate separate `.notebooks` repos — use gh-pages instead
-
-**Rationale:**
-- Users access notebooks via: (1) download links on lecture pages, (2) Colab badges on lecture pages
-- `build-lectures` already copies notebooks to `_build/html/_notebooks` via `html-copy-notebooks: 'true'`
-- Colab supports opening from any URL: `colab.research.google.com/notebook?url=https://python.quantecon.org/_notebooks/example.ipynb`
-- Eliminates sync step, reduces repo count by 4, single source of truth
-
-**Migration:**
-1. Update `quantecon-book-theme` to generate Colab URLs pointing to gh-pages instead of `.notebooks` repos ([quantecon-book-theme#359](https://github.com/QuantEcon/quantecon-book-theme/issues/359))
-2. Deploy updated theme + notebooks to gh-pages
-3. Archive/deprecate `.notebooks` repos with redirect notices
+| # | Item | Refs |
+|---|---|---|
+| 13 | Merge safe Dependabot PRs: #90 (checkout v7, cache v6 — first-party runtime bumps) and #88 (`action-gh-release` 3.0.1 patch, SHA-pinned). | PRs #90/#88 |
+| 14 | Harden `create-failure-issue.sh`: distinguish "no existing issue" from "list failed", surface `::error::` when creation fails, use `mktemp` instead of a fixed `/tmp` path. | #83 |
+| 15 | Small fixes: `set -euo pipefail` in `check-latex-versions.sh`; `concurrency` + `timeout-minutes` in `build-containers.yml`; fix the `build-lectures` pdflatex debug hint path (`_build/latex/reports`); refresh stale README blocks in `setup-environment` (cache strategy) and `restore-jupyter-cache` (phantom "Age Information"). | — |
+| 16 | Branch hygiene: delete the merged `fix-conda-activation` branch and prune the five stale (~5 months old) feature branches after confirming nothing is stranded. | — |
+| 17 | Refresh TESTING.md dated status. | — |
 
 ---
 
-## Standalone Workflows (Not Migrated)
+## Dependency policy
 
-These workflows are independent of the build chain and can remain as-is:
+The lean image's science stack (`numpy`, `scipy`, `pandas`, …) is **pinned as a set** to the Anaconda baseline the lecture repos pin (currently `anaconda=2025.12`). Drifting individual packages ahead of that baseline is what broke lecture execution in #28.
 
-### Colab Compatibility Testing (`collab.yml`)
-
-Runs weekly inside a Google Colab container (`us-docker.pkg.dev/colab-images/public/runtime:latest` with `--gpus all`) to verify notebooks execute in the Colab environment. Creates a GitHub issue on failure.
-
-**Decision:** Keep as standalone workflow. Not part of the build/deploy chain.
-
-### Link Checking (`linkcheck.yml`)
-
-Runs weekly against the `gh-pages` branch using `lycheeverse/lychee-action@v2`. Creates a GitHub issue on broken links.
-
-**Decision:** Keep as standalone workflow. Could become a reusable action later if other repos want it.
+- Stack bumps happen as **one coordinated move** — both containers together, only when the lecture repos adopt a new anaconda baseline, validated by a container lecture-build run (and, once built, the #29 env-test harness).
+- Dependabot handles everything else: minors/patches grouped per ecosystem, majors grouped for individual review (#67, #76). The conda stack should be excluded via `ignore` (backlog item 3).
+- Urgent security fixes may cherry-pick a single package, with the deviation documented in `environment.yml`.
 
 ---
 
-## Feature Parity Checklist
+## Open issues disposition
 
-All features needed to fully replace current lecture-repo workflows:
+| Issue | Status (July 2026 review) | Disposition |
+|---|---|---|
+| #83 cache failures silent | Partially addressed — `@main` sub-action pins and the literal script-not-found 127 are fixed; the container `gh` gap and missing failure reports remain | Backlog items 1, 2, 14 |
+| #14 Cloudflare alias URL | Still valid | Backlog item 5 |
+| #29 composite-vs-workflow docs + env harness | Still valid | Backlog items 9, 11 |
+| #30 env/config manifest | Partially addressed — v0 stub exists | Backlog item 12 |
+| #18 container-mode caching | Re-scoped — pre-baking covers the common stack; only the per-lecture delta install is uncached. Quantify before investing | Keep open, low priority |
+| #27 HTML recovery tool | Still valid — producer half exists (release assets + checksums); consumer unbuilt. Likely belongs in `workflow-backups`, not here | Decide home, then build |
+| #2 isolated lecture execution | Exploratory — most tractable first step is an execution check of the built notebooks | Keep open, low priority |
 
-### Remaining
+---
 
-- [ ] **Verify `actions/cache` on RunsOn** — Test cache save/restore on self-hosted GPU runners
-- [ ] **Verify OIDC Pages deployment from RunsOn** — Test native GH Pages deploy from self-hosted runners
+## Rollout status
 
-### Completed ✅
+### Phase 1: `lecture-dp` — ✅ complete
 
-- [x] **Architectural decision: Eliminate `.notebooks` repos** — Use gh-pages for Colab integration, update theme URL generation
-- [x] **Download Notebooks Zip** — Inline workflow step (simple one-liner, not needed as action feature)
-- [x] Execution reports on failure (`build-lectures` — `upload-failure-reports`)
-- [x] Asset assembly (`build-lectures` — `html-copy-pdf`, `html-copy-notebooks`)
-- [x] Dedicated cache actions (`build-jupyter-cache`, `restore-jupyter-cache`)
-- [x] PR-scoped build caching (`restore-jupyter-cache` — `save-cache`)
-- [x] Native GitHub Pages deployment (OIDC, no gh-pages branch)
-- [x] Release assets with tarball, checksum, manifest (`publish-gh-pages`)
-- [x] Netlify PR preview deployment (`preview-netlify`)
-- [x] Cloudflare Pages PR preview deployment (`preview-cloudflare`)
-- [x] Changed file detection for PR comments
-- [x] Conda environment caching (standard mode)
-- [x] LaTeX installation with requirements file
-- [x] JAX/PyTorch ML libs — managed via repo `environment.yml` (not hardcoded in action)
-- [x] Multi-builder support (html, pdflatex, jupyter)
-- [x] Container-aware environment setup (marker file detection)
-- [x] Delta package installs (`environment-update` input)
-- [x] Issue creation on build failure (`build-jupyter-cache`)
+`lecture-dp` runs the full chain (`restore-jupyter-cache` → `build-lectures` → `build-jupyter-cache` → `publish-gh-pages`) in production at `@v0.8.0`. Production use surfaced the #83 alerting gaps — the motivation for the P0 item above.
+
+### Phase 2: migrate existing repos
+
+Incremental migration, previews first (see [meta#327](https://github.com/QuantEcon/meta/issues/327)), CPU-only full chains next, GPU last:
+
+| # | Repository | Runner | Status |
+|---|---|---|---|
+| 1 | `lecture-python.myst` (previews) | GPU | ✅ `preview-netlify@v0.8.0` live |
+| 2 | Remaining python repos (previews) | Container | ⏳ meta#327 pilots |
+| 3 | `lecture-python-intro` (full chain) | Container | ⏳ Planned |
+| 4 | `lecture-python-programming.myst` (full chain) | Container | ⏳ Planned |
+| 5 | `lecture-python-advanced.myst` (full chain) | Container | ⏳ Planned |
+| 6 | `lecture-python.myst` (full chain) | RunsOn GPU | ⏳ Blocked on RunsOn verification (below) |
+
+Per-repo checklist: create migration branch → `setup-environment` → `build-lectures` → cache actions → preview action → `publish-gh-pages` → validate output against production → measure → merge and monitor.
+
+### Remaining blockers for the GPU repo
+
+The February 2026 gap analysis concluded every `lecture-python.myst` build feature is supported (full matrix in git history). Two verification items remain before its full-chain migration:
+
+- [ ] **`actions/cache` on RunsOn** — confirm cache save/restore works on the self-hosted GPU runners
+- [ ] **OIDC Pages deployment from RunsOn** — confirm `actions/deploy-pages` token flow works from self-hosted runners
+
+Settled architectural decisions: eliminate the `.notebooks` repos in favour of gh-pages notebooks + theme-generated Colab URLs ([quantecon-book-theme#359](https://github.com/QuantEcon/quantecon-book-theme/issues/359)); notebook-zip stays an inline workflow step; `collab.yml` and `linkcheck.yml` remain standalone workflows.

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ We're in the `0.x` development phase (pre-1.0.0). Reference the actions with:
 - **[docs/GPU-AMI-SETUP.md](./docs/GPU-AMI-SETUP.md)** - Building RunsOn GPU AMI
 - **[docs/FUTURE-DEVELOPMENT.md](./docs/FUTURE-DEVELOPMENT.md)** - GPU support and roadmap
 - **[TESTING.md](./TESTING.md)** - Testing strategy
-- **[PLAN.md](./PLAN.md)** - Migration plan and feature parity status
+- **[PLAN.md](./PLAN.md)** - Current work plan, backlog, and rollout status
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

PLAN.md was a migration-plan snapshot frozen in February 2026. Since then Phase 1 shipped — `lecture-dp` runs the full chain in production at `@v0.8.0` — and a deep technical review (July 2026) of all actions, containers, workflows, docs, and every open issue/PR produced a prioritized backlog that had no home. This PR rewrites PLAN.md as the repo's single forward-looking work plan and updates the README pointer line to match. Net −81 lines.

## What changed

**Current state** now reflects reality: v0.8.0, the June 2026 hardening pass (see #79, #36, #35, #78, #84), a verified consumer table (`lecture-dp` full chain at `@v0.8.0`, `lecture-python.myst` previews at `@v0.8.0`, `test-lecture-python-intro` at `@v0.6.0`), and an honest note that container-mode failure alerting is currently broken (see #83).

**Backlog (P0–P3)** from the review, headlined by:

| Priority | Item |
|---|---|
| P0 | Container-mode failure alerting: neither container image installs the `gh` CLI, so `create-failure-issue.sh` exits 127 in the documented default configuration — every cache-build failure goes un-alerted (see #83) |
| P1 | Targeted execution reports on cache failure; fix Dependabot conda grouping; hold PRs #86/#87; stable `pr-N` alias URL for preview-cloudflare (see #14) |
| P2 | Surplus removal: shared PR-comment script, dead `asset-url` output, Netlify token via `env:`, standard-mode cache CI coverage, docs trim (see #29, #30, #40) |
| P3 | Safe Dependabot merges (#90, #88), script hardening, small fixes, branch hygiene |

**Dependency policy** section codifies the "bump the science stack as a set" invariant from #28 and records the hold on PRs #86/#87 — both drift the containers off the Anaconda 2025.12 baseline the lecture repos pin, and #87 additionally pulls in pandas 3.0 (major).

**Open issues disposition** table summarises the triage of all 7 open issues (#83, #14, #29, #30, #18, #27, #2) against current `main`.

**Rollout status** replaces the stale Phase 1/2 tables: Phase 1 is complete, previews-first migration is tracked in QuantEcon/meta#327, and the completed February gap analysis is compressed to its two remaining RunsOn verification blockers (the full feature matrix stays in git history).

## Verification

Every factual claim in the new PLAN.md was adversarially checked against the current tree and live consumer repos (via `gh api` on `lecture-dp`, `lecture-python.myst`, and `test-lecture-python-intro` workflows): 12 of 13 checkable claims confirmed exactly; the two figures that failed verification (consumer version cell, docs line count) were corrected before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)