### PR TITLE
Migrate both containers to the Anaconda 2026.06 baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,10 @@ updates:
   # The conda ecosystem (GA Dec 2025) tracks the `pip:` block (jupyter-book,
   # quantecon-book-theme, the sphinx-* extensions, kaleido) via PyPI, and also
   # proposes version-range bumps for conda deps such as `nodejs` — which is why
-  # it's capped in the ignore list below. The `anaconda` metapackage is pinned
-  # to a date version (`=2025.12`), so it stays put.
+  # it's capped in the ignore list below. The core scientific stack (numpy, scipy,
+  # pandas, … and the `anaconda` metapackage) is held at the 2026.06 baseline via
+  # `ignore` below — a date-pin like `=2026.06` does NOT stop Dependabot proposing
+  # the next release, so each is listed explicitly.
   - package-ecosystem: "conda"
     directories:
       - "/containers/quantecon"
@@ -42,6 +44,24 @@ updates:
     ignore:
       # Python is pinned deliberately (matched to the image base); bump manually.
       - dependency-name: "python"
+      # Core scientific stack — held at the Anaconda 2026.06 baseline the lecture
+      # repos build against (see containers/quantecon-build/environment.yml, issue
+      # #28 / PR #84). Pinned individually in the lean image and via the `anaconda`
+      # metapackage in the full image; bump them together, manually, in step with
+      # the lecture repos on the next Anaconda release. Ignore every update type so
+      # Dependabot neither drifts them individually (minor/patch, e.g. numpy past
+      # 2.4.6) nor jumps the next major ahead of that coordinated bump.
+      - dependency-name: "numpy"
+      - dependency-name: "scipy"
+      - dependency-name: "pandas"
+      - dependency-name: "matplotlib"
+      - dependency-name: "seaborn"
+      - dependency-name: "sympy"
+      - dependency-name: "numba"
+      - dependency-name: "networkx"
+      - dependency-name: "statsmodels"
+      - dependency-name: "scikit-learn"
+      - dependency-name: "anaconda"
       # jupyter-book 2.x is a major rewrite — stay on 1.x until we opt in.
       - dependency-name: "jupyter-book"
         update-types: ["version-update:semver-major"]

--- a/containers/quantecon-build/environment.yml
+++ b/containers/quantecon-build/environment.yml
@@ -9,23 +9,24 @@ dependencies:
   # Python
   - python=3.13
   
-  # Core scientific stack — pinned to the Anaconda 2025.12 baseline that every
-  # QuantEcon lecture repo builds against (they pin `anaconda=2025.12`), keeping
+  # Core scientific stack — pinned to the Anaconda 2026.06 baseline that every
+  # QuantEcon lecture repo builds against (they pin `anaconda=2026.06`), keeping
   # this lean image reproducible and consistent with the full `quantecon` image
   # and the source repos. Left unpinned, the stack drifted ahead of that baseline
   # and produced non-reproducible images that broke notebook execution downstream
   # (e.g. un_insure.md's fsolve call; see #28).
-  # Bump as a set when the lecture repos move to a newer anaconda release.
-  - numpy=2.3.5
-  - scipy=1.16.3
-  - pandas=2.3.3
-  - matplotlib=3.10.6
+  # Versions are the anaconda=2026.06 linux-64 py313 (MKL) pins; bump as a set
+  # when the lecture repos move to a newer anaconda release.
+  - numpy=2.4.6
+  - scipy=1.17.1
+  - pandas=3.0.3
+  - matplotlib=3.10.9
   - seaborn=0.13.2
   - sympy=1.14.0
-  - numba=0.62.1
-  - networkx=3.5
-  - statsmodels=0.14.5
-  - scikit-learn=1.7.2
+  - numba=0.65.1
+  - networkx=3.6.1
+  - statsmodels=0.14.6
+  - scikit-learn=1.8.0
   
   # CPU acceleration (Intel MKL for optimized linear algebra)
   - mkl

--- a/containers/quantecon/environment.yml
+++ b/containers/quantecon/environment.yml
@@ -8,7 +8,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.13
-  - anaconda=2025.12  # Full Anaconda: numpy, scipy, pandas, matplotlib, seaborn, sympy, jupyter, jupyterlab, ipywidgets, networkx, statsmodels, numba, and 400+ more
+  - anaconda=2026.06  # Full Anaconda: numpy, scipy, pandas, matplotlib, seaborn, sympy, jupyter, jupyterlab, ipywidgets, networkx, statsmodels, numba, and 400+ more
   - nodejs>=20,<25    # netlify-cli (preview-netlify) + jupyterlab; capped at node 24 LTS (exclude non-LTS 25)
   - pip
   - pip:


### PR DESCRIPTION
## What

Moves both container images to the **Anaconda 2026.06** baseline — matching the QuantEcon lecture repos, which now all pin `anaconda=2026.06` — and holds them there via Dependabot's ignore list.

- **Full `quantecon` image** — `anaconda=2025.12` → `anaconda=2026.06`.
- **Lean `quantecon-build` image** — repins the individually-pinned scientific stack to the exact versions `anaconda=2026.06` resolves to on linux-64 / py313 (the MKL build).
- **`.github/dependabot.yml`** — adds the scientific stack + `anaconda` to the conda `ignore` block so Dependabot stops re-proposing off-baseline bumps. Supersedes #86 and #87.

## Lean-container versions (2025.12 → 2026.06)

| Package | Was | Now |
|---|---|---|
| numpy | 2.3.5 | 2.4.6 |
| scipy | 1.16.3 | 1.17.1 |
| pandas | 2.3.3 | 3.0.3 |
| matplotlib | 3.10.6 | 3.10.9 |
| seaborn | 0.13.2 | 0.13.2 |
| sympy | 1.14.0 | 1.14.0 |
| numba | 0.62.1 | 0.65.1 |
| networkx | 3.5 | 3.6.1 |
| statsmodels | 0.14.5 | 0.14.6 |
| scikit-learn | 1.7.2 | 1.8.0 |

These are the deliberate coordinated-bump versions, resolved authoritatively rather than taken from Dependabot's "latest" — which overshoots the baseline (it proposed numpy 2.5.0, scipy 1.18.0, matplotlib 3.11.0, scikit-learn 1.9.0). linux-64 keeps MKL as the default BLAS, so the existing `mkl` / `mkl-service` pins are unchanged. Resolved with:

```bash
conda search 'anaconda=2026.06' --info -c defaults --subdir linux-64
```

## Validation

The 2026.06 stack (including the pandas 2→3 jump) is already exercised by the lecture repos' own CI, since they build against `anaconda=2026.06` — this PR just brings the containers into line with an already-validated baseline. Note the container tests (`test-containers-lectures.yml`) run post-merge on `:latest` via `workflow_run`, so this can't be fully validated pre-merge; worth watching that run once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)