### PR TITLE
ci: repair the container publish and validation pipeline

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -16,14 +16,26 @@ on:
         required: false
         default: 'all'
 
+# Both jobs push `:latest`, and every consumer pins `:latest`. Without this the
+# older of two overlapping runs can finish last and win the tag.
+concurrency:
+  group: build-containers-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
+  # GHCR image paths must be lowercase, so `github.repository_owner` (which
+  # preserves the `QuantEcon` casing) cannot be substituted into an image ref.
+  # buildx treats a rejected cache ref as non-fatal, so getting this wrong makes
+  # every build silently cold rather than failing.
+  IMAGE_NAMESPACE: quantecon
 
 jobs:
   build-quantecon:
     name: Build quantecon (Full)
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.container == 'all' || github.event.inputs.container == 'quantecon' }}
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -45,7 +57,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/quantecon
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/quantecon
           tags: |
             type=raw,value=latest
             type=sha,prefix={{branch}}-
@@ -58,13 +70,14 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/quantecon:latest
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/quantecon:latest
           cache-to: type=inline
 
   build-quantecon-build:
     name: Build quantecon-build (Lean)
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.container == 'all' || github.event.inputs.container == 'quantecon-build' }}
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -86,7 +99,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/quantecon-build
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/quantecon-build
           tags: |
             type=raw,value=latest
             type=sha,prefix={{branch}}-
@@ -99,5 +112,28 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/quantecon-build:latest
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/quantecon-build:latest
           cache-to: type=inline
+
+  notify-failure:
+    name: Report failure
+    runs-on: ubuntu-latest
+    needs: [build-quantecon, build-quantecon-build]
+    # Scheduled and push runs have nobody watching them. Manual dispatches do.
+    if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Open or update the failure tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_LABELS: bug,infrastructure
+        run: ./scripts/create-ci-failure-issue.sh

--- a/.github/workflows/check-latex-versions.yml
+++ b/.github/workflows/check-latex-versions.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   check-versions:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
       

--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -15,6 +15,10 @@ jobs:
     name: Test quantecon (Full)
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -61,6 +65,10 @@ jobs:
     name: Test quantecon-build (Lean)
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/test-containers-lectures.yml
+++ b/.github/workflows/test-containers-lectures.yml
@@ -4,9 +4,17 @@ name: Test Container Builds
 # Architecture: Each job builds one repo × one container through the full
 # builder pipeline (html → pdflatex → jupyter) sequentially.
 #
-# Concurrency groups ensure the same repo never builds on two containers
-# simultaneously, avoiding network contention from concurrent dataset
+# The job-level concurrency group ensures the same repo never builds on two
+# containers simultaneously, avoiding network contention from concurrent dataset
 # downloads. Different repos can run in parallel.
+#
+# That group is scoped by run id on purpose. A concurrency group holds one
+# running job plus one pending job — a third arrival evicts the pending one — so
+# an unscoped group let a second run silently cancel the first run's queued
+# matrix legs, and `cancelled` does not read as a regression. Run-id scoping caps
+# each group at the number of containers in the matrix; keep that at two, or the
+# eviction returns. Overlapping runs are handled by the workflow-level group
+# below instead, where superseding is explicit.
 #
 # The `quantecon` GHCR org is intentionally hardcoded (GHCR image paths must be
 # lowercase, so github.repository_owner — which preserves casing — can't be substituted here).
@@ -18,15 +26,25 @@ on:
       - completed
   workflow_dispatch:
 
+concurrency:
+  group: test-containers-lectures-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     timeout-minutes: 120
 
-    # Serialize containers for the same repo to avoid concurrent downloads
+    permissions:
+      contents: read
+      packages: read
+
+    # Serialize containers for the same repo to avoid concurrent downloads.
+    # Scoped by run id so queued legs are never evicted by a later run — see the
+    # note at the top of this file.
     concurrency:
-      group: test-build-${{ matrix.repo.repo }}
+      group: test-build-${{ github.run_id }}-${{ matrix.repo.repo }}
       cancel-in-progress: false
 
     strategy:
@@ -110,3 +128,27 @@ jobs:
           name: build-${{ matrix.container }}-${{ matrix.repo.repo }}
           path: lecture-repo/_build
           retention-days: 3
+
+  notify-failure:
+    name: Report failure
+    runs-on: ubuntu-latest
+    needs: [test]
+    # This workflow runs unattended off the weekly container build. Manual
+    # dispatches have someone watching them.
+    if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout actions repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Open or update the failure tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_LABELS: bug,infrastructure
+        run: ./scripts/create-ci-failure-issue.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CI**: `test-containers-lectures.yml` and `build-containers.yml` now open (or comment on) a
+  deduplicated tracking issue when they fail, via the new
+  `scripts/create-ci-failure-issue.sh`. Both run unattended — off a weekly schedule and off
+  `workflow_run` — and had no alert path: container validation was red for nine consecutive weeks
+  in Feb–Apr 2026 with nothing surfacing it. One open issue is kept per workflow; repeat failures
+  are appended as comments. Manual `workflow_dispatch` runs are excluded, since those have someone
+  watching. (#103)
+
 ### Fixed
+- **CI**: The buildx registry layer cache in `build-containers.yml` now resolves. Both `cache-from`
+  refs interpolated `github.repository_owner`, which preserves the `QuantEcon` casing; buildx
+  rejects `ghcr.io/QuantEcon/...` as "repository name must be lowercase" and treats a failed cache
+  import as non-fatal, so every container build since the cache was added has been cold — and green.
+  The namespace is now a lowercase `IMAGE_NAMESPACE` env var used by both jobs. (#103)
+- **CI**: Added a workflow-level `concurrency` group to `build-containers.yml`. Both jobs push
+  `:latest` and every consumer pins `:latest`, but nothing serialised the workflow — on 2026-07-08
+  two overlapping runs meant the *older* commit's build finished last and won the tag. (#103)
+- **CI**: `test-containers-lectures.yml` no longer silently cancels most of its matrix. The
+  job-level group `test-build-${{ matrix.repo.repo }}` was shared across runs, and a concurrency
+  group holds only one running plus one pending job, so a later run evicted the earlier run's queued
+  legs — all three runs on 2026-07-08 concluded `cancelled`, which does not read as a regression.
+  The group is now scoped by run id, with superseding handled explicitly by a workflow-level group.
+  This is the only workflow that exercises `setup-environment` and `build-lectures` against real
+  lecture content. (#103)
+- **CI**: Added `permissions:` and `timeout-minutes` to the workflows that declared neither
+  (`test-container.yml`, `check-latex-versions.yml`), `permissions:` to
+  `test-containers-lectures.yml`, and `timeout-minutes` to the `build-containers.yml` build jobs.
+  (#103)
 - **Containers (quantecon-build)**: Pinned the lean image's core scientific stack (numpy, scipy,
   pandas, matplotlib, seaborn, sympy, numba, networkx, statsmodels, scikit-learn) to the Anaconda
   2025.12 baseline that every lecture repo builds against (via `anaconda=2025.12`), instead of

--- a/scripts/create-ci-failure-issue.sh
+++ b/scripts/create-ci-failure-issue.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Open (or update) a tracking issue when one of this repository's own unattended
+# workflows fails.
+#
+# Scheduled and workflow_run builds have no author watching them: container
+# validation ran red for nine consecutive weeks in Feb-Apr 2026 and nothing
+# surfaced it. This is the alert path for those runs.
+#
+# One open issue is kept per workflow. Repeat failures are appended as comments,
+# so the issue accumulates a history instead of the tracker filling with
+# duplicates.
+#
+# Required environment variables (all but GH_TOKEN are set by the runner):
+#   GH_TOKEN           - token with `issues: write` on this repository
+#   GITHUB_REPOSITORY  - owner/repo
+#   GITHUB_RUN_ID      - workflow run id
+#   GITHUB_SERVER_URL  - e.g. https://github.com
+#   GITHUB_WORKFLOW    - workflow name (used as the dedupe key)
+#
+# Optional:
+#   ISSUE_LABELS       - comma-separated labels (default: bug,infrastructure).
+#                        The first label is the one the dedupe lookup is scoped
+#                        to, so it must be applied to every issue this script
+#                        creates, and it must already exist on the repository.
+
+set -euo pipefail
+
+for var in GH_TOKEN GITHUB_REPOSITORY GITHUB_RUN_ID GITHUB_SERVER_URL GITHUB_WORKFLOW; do
+  if [ -z "${!var:-}" ]; then
+    echo "::error::$var is required but is not set"
+    exit 1
+  fi
+done
+
+ISSUE_LABELS="${ISSUE_LABELS:-bug,infrastructure}"
+DEDUPE_LABEL="$(printf '%s' "$ISSUE_LABELS" | cut -d, -f1 | xargs)"
+
+TITLE="🔴 CI failure: ${GITHUB_WORKFLOW}"
+RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+# Which legs failed. Needs `actions: read`; degrade to the run link if absent.
+FAILED_JOBS="$(gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --json jobs \
+  | jq -r '[.jobs[] | select(.conclusion == "failure") | "- `" + .name + "`"] | join("\n")' \
+  || true)"
+
+BODY_FILE="$(mktemp)"
+trap 'rm -f "$BODY_FILE"' EXIT
+
+{
+  echo "## 🔴 \`${GITHUB_WORKFLOW}\` failed"
+  echo
+  echo "| | |"
+  echo "|---|---|"
+  echo "| **Run** | [${GITHUB_RUN_ID}](${RUN_URL}) |"
+  echo "| **Trigger** | \`${GITHUB_EVENT_NAME:-unknown}\` |"
+  echo "| **Branch** | \`${GITHUB_REF_NAME:-unknown}\` |"
+  echo "| **Commit** | ${GITHUB_SHA:-unknown} |"
+  echo "| **Failed at** | $(date -u +'%Y-%m-%d %H:%M UTC') |"
+  echo
+  if [ -n "$FAILED_JOBS" ]; then
+    echo "### Failed jobs"
+    echo
+    echo "$FAILED_JOBS"
+    echo
+  fi
+  echo "Nobody was watching this run, so this issue is the alert. The [run log](${RUN_URL}) shows what broke, and any job that uploads artifacts has attached its build output and failure reports to the run."
+  echo
+  echo "Close this issue once the workflow is green again — the next failure opens a fresh one."
+} > "$BODY_FILE"
+
+EXISTING="$(gh issue list \
+  --repo "$GITHUB_REPOSITORY" \
+  --state open \
+  --label "$DEDUPE_LABEL" \
+  --limit 100 \
+  --json number,title \
+  | jq -r --arg title "$TITLE" 'map(select(.title == $title)) | .[0].number // empty')"
+
+if [ -n "$EXISTING" ]; then
+  echo "Existing open issue #${EXISTING} — recording this failure as a comment"
+  gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body-file "$BODY_FILE"
+else
+  echo "No open issue for this workflow — opening one"
+  gh issue create \
+    --repo "$GITHUB_REPOSITORY" \
+    --title "$TITLE" \
+    --body-file "$BODY_FILE" \
+    --label "$ISSUE_LABELS"
+fi


### PR DESCRIPTION
Closes #103.

Four independent defects in the container publish/validation pipeline, all of which currently show **green** in CI, plus the `permissions:`/`timeout-minutes` gaps in the same files.

## 1. `cache-from` interpolated the mixed-case org

Both cache refs were built from `github.repository_owner`, which is `QuantEcon`. buildx rejects `ghcr.io/QuantEcon/...` with *"repository name must be lowercase"* and treats a cache-import failure as non-fatal — so every container build has been cold and the workflow still passed.

Rather than hardcoding the string twice, the namespace is now a lowercase `IMAGE_NAMESPACE` env var shared by both jobs, with the constraint written down next to it. The audit noted this bug had to be fixed in two places precisely because the two jobs are copies of each other; a single env var means the next copy-paste can't reintroduce it. `images:` now uses it too — `docker/metadata-action` lowercases image names itself, so that line was never broken, but leaving one mixed-case interpolation in the file next to the fixed ones is how this comes back.

## 2. No concurrency group on `build-containers.yml`

Nothing serialised the workflow and both jobs push `type=raw,value=latest`. On 2026-07-08 two overlapping runs meant the **older** commit's build finished last. Every consumer pins `:latest`. Now a workflow-level group with `cancel-in-progress: true`.

## 3. The lecture-validation matrix silently cancelled most of its jobs

A concurrency group holds one running job plus one pending job — a third arrival evicts the pending one. The group `test-build-${{ matrix.repo.repo }}` was shared across runs, so a later run silently cancelled the earlier run's queued matrix legs, and `cancelled` does not read as a regression. All three runs on 2026-07-08 concluded `cancelled`. This is the only workflow that exercises `setup-environment` and `build-lectures` against real lecture content.

The group is now scoped by `github.run_id`, which preserves exactly the behaviour the group was added for — the 2026-07-20 run shows each repo's second container starting the moment the first finishes — while capping each group at the matrix's container count, so nothing is ever evicted. Overlapping runs are handled instead by a workflow-level group where superseding is explicit and visible.

I went with the run-id option rather than `strategy.max-parallel` because max-parallel gives no guarantee about *which* legs run together: it would depend on matrix expansion order, which isn't documented, and the whole point of the group is that a given repo isn't downloaded twice at once. The tradeoff is that run-id scoping is only safe while the container matrix has two entries — a third would bring the eviction back — so that constraint is now stated in the header comment.

## 4. No failure notification on any unattended workflow

`gh run list` shows unbroken `failure` on container validation from 2026-02-16 through 2026-04-20 — nine consecutive weeks — plus 06-16 and 06-22, with nothing surfacing it. The repo shipped `create-failure-issue.sh` for its consumers and used it on none of its own workflows.

New `scripts/create-ci-failure-issue.sh`, called from an `if: failure()` job on both unattended workflows. It keeps **one open issue per workflow**, keyed on the title, and appends repeat failures as comments so the issue accumulates a history instead of the tracker filling with duplicates. Where `actions: read` is available it lists which matrix legs failed, which matters for a six-leg matrix; without it the body degrades to the run link rather than failing. Manual `workflow_dispatch` runs are excluded — those have someone watching. Labels are `bug,infrastructure`, both of which already exist on the repo; the first is also the dedupe scope.

## 5. Under-declared workflows

| Workflow | Added |
|---|---|
| `test-container.yml` (both jobs) | `permissions: contents/packages: read`, `timeout-minutes: 30` |
| `check-latex-versions.yml` | `permissions: contents: read`, `timeout-minutes: 15` |
| `test-containers-lectures.yml` | `permissions: contents/packages: read` (already had a timeout) |
| `build-containers.yml` (both build jobs) | `timeout-minutes: 60` (already had permissions) |

`packages: read` is load-bearing rather than cosmetic on the jobs that pull from GHCR: declaring a `permissions:` block drops every scope not listed, so the image pull needs it back explicitly. Timeouts are set well above observed runtimes — builds take ~8 min, container smoke tests ~2.5 min, the longest lecture leg ~55 min.

## Testing

The workflows are all `schedule`/`workflow_run`/`workflow_dispatch`-triggered, so none of them runs on this PR. What I did check:

- All four workflow files parse, and job graphs are as intended.
- `shellcheck` is clean on the new script.
- The script was exercised locally against a stubbed `gh` for four paths: no existing issue (creates), an existing issue for the same workflow among other open issues (matches #42, comments), `gh run view` returning 403 (drops the *Failed jobs* section, exits 0), and a missing required env var (fails with a `::error::` annotation).

I deliberately did **not** dispatch `build-containers.yml` from this branch to demo a cache hit: `type=raw,value=latest` is unconditional, so a branch run would overwrite the published `:latest`. The remaining checklist item on #103 — confirming a cache **hit** in the buildx log — needs the first scheduled or push-triggered run after merge. The run after that is the one to read: this merge repopulates `:latest` with usable inline cache, and the run following it should show `CACHED` layers and a build materially faster than the current ~8 min.

Note that the notification job can only be proven by a real failure. Its own failure is silent by construction — if it misbehaves, the symptom is the status quo.
