### PR TITLE
Harness follow-ups from #116: attribute the negative build test, document the -W dependence

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -12,6 +12,15 @@
 # byte-for-byte and are ordered with `needs:` (actions/cache saves are visible
 # across jobs of the same run).
 #
+# Consequence: "Re-run failed jobs" can never go green. It increments
+# run_attempt — and therefore the salt, and therefore every cache key — but
+# does NOT re-run the already-green seed jobs, so unit-build-restore,
+# unit-build-restore-save, unit-exec-restore*, env-hit-build and the bjc-*
+# round-trips all end up looking for caches nobody saved under the new salt.
+# Always use "Re-run all jobs". Do not "fix" this by dropping run_attempt from
+# the salt: run_id alone would let attempt 2 reuse attempt 1's caches and
+# silently invalidate the miss assertions.
+#
 # Two constraints shape what this harness can and cannot assert:
 #
 #   1. actions/cache matches a key only when the cache "version" (a hash of
@@ -426,7 +435,30 @@ jobs:
           OUTCOME: ${{ steps.build.outcome }}
         run: |
           [ "$OUTCOME" = "failure" ] || { echo "::error::build-lectures reported [$OUTCOME] for a build whose execution raised — a failing build must fail the step"; exit 1; }
-          echo "✅ a failing build fails the step (exit status propagates)"
+
+          # Attribute the red. A `failure` outcome on its own is also satisfied
+          # by a build that died on some unrelated -W warning, which would let
+          # this job stay green while the property it guards was broken.
+          # myst-nb writes the execution traceback to
+          # <sphinx outdir>/reports/<docname>.err.log (myst_nb/sphinx_.py), and
+          # `jb build harness/lectures --path-output harness` with builder html
+          # puts outdir at harness/_build/html. Hard-coded rather than globbed:
+          # this is the same path build-lectures ships in upload-failure-reports,
+          # so if jupyter-book ever relocates reports/ this goes red here rather
+          # than that upload silently producing an empty artifact.
+          # Keep the $OUTCOME check above this one — a stale err.log survives an
+          # incremental rebuild that exits 0, so the file existing is not by
+          # itself evidence that the build failed.
+          REPORT=harness/_build/html/reports/broken.err.log
+          if [ ! -f "$REPORT" ]; then
+            echo "::error::the build failed but never wrote $REPORT — the red is not attributable to the staged execution error. If jupyter-book moved the execution-report directory, fix this path and build-lectures' upload-failure-reports paths together."
+            find harness -maxdepth 3 -type d -print || true
+            exit 1
+          fi
+          grep -q 'harness: deliberate build failure' "$REPORT" \
+            || { echo "::error::$REPORT is not the failure this job stages (missing the fixture's assertion message)"; sed -n '1,60p' "$REPORT"; exit 1; }
+
+          echo "✅ a failing build fails the step, and the red is the staged CellExecutionError ($REPORT)"
 
   # ==========================================================================
   # build-jupyter-cache — smoke + round-trip into restore-jupyter-cache.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   publish/preview coverage and the `@v0` sibling-pin chain remain with the post-release canary
   proposed there. (#100)
 
+### Changed
+- **build-lectures**: documented that `-W` is load-bearing for build failure. A code cell that
+  raises is only a *warning* to Jupyter Book, so `-W` in the `extra-args` default is the sole
+  reason a broken lecture fails the build — and `extra-args` replaces the default rather than
+  extending it. Overriding it without `-W` yields a published site, an error-report page, and
+  exit 0. The README now says so next to the default, and the Troubleshooting entry that
+  suggested bare `--keep-going` is corrected (it does nothing without `-W`). (#116)
+- **CI**: `build-fail-guard` now attributes its expected failure instead of accepting any red.
+  Asserting only `outcome == failure` would also have been satisfied by a build that died on an
+  unrelated `-W` warning; the job now requires the staged `CellExecutionError` traceback in
+  `harness/_build/html/reports/broken.err.log`. Also recorded in the workflow header that
+  "Re-run failed jobs" can never go green on this harness — it bumps `run_attempt`, and so the
+  cache salt, without re-running the seed jobs that saved under the old salt. (#116)
+
 ### Fixed
 - **build-lectures**: on hosted (non-container) runners, a **successful build failed the step
   anyway**. The build step runs in a login shell (`bash -l`, required for conda activation) and

--- a/build-lectures/README.md
+++ b/build-lectures/README.md
@@ -182,7 +182,23 @@ See the [cache actions documentation](../build-jupyter-cache/README.md) for setu
 `-W --keep-going`
 
 - `-W`: Treat warnings as errors
-- `--keep-going`: Continue on errors
+- `--keep-going`: meaningful only alongside `-W` — collect every warning-as-error instead of
+  stopping at the first, then exit non-zero at the end of the build. On its own it does nothing.
+
+> **Warning:** keep `-W` in any `extra-args` you set.
+>
+> A code cell that raises is not an error to Jupyter Book. `myst-nb` logs the failed execution as
+> a *warning* and carries on — `raise_on_error` under `execute:` in `_config.yml` (Sphinx:
+> `nb_execution_raise_on_error`) defaults to `false`. `-W` is the only thing that turns that
+> warning into a non-zero exit, and `extra-args` **replaces** the default rather than adding to it.
+>
+> So a build with `extra-args` set but `-W` omitted publishes the site, writes
+> `_build/<builder>/reports/<page>.err.log`, and exits **0** — a green CI run over a broken
+> lecture.
+>
+> Setting `raise_on_error: true` in `_config.yml` is an alternative, but a blunter one: myst-nb
+> then raises instead of warning, so the build aborts at the first failing notebook and never
+> writes the `reports/` tracebacks that `upload-failure-reports` collects. Prefer `-W`.
 
 ### Common Extra Arguments
 
@@ -215,7 +231,8 @@ extra-args: '-W --keep-going --all'
 **Solutions:**
 1. Check specific notebook in build logs
 2. Run locally: `jb build lectures`
-3. Use `--keep-going` to see all errors
+3. Re-run locally the way CI does — `jb build lectures -W --keep-going` — to see every error that
+   fails the build (`--keep-going` without `-W` reports nothing extra)
 4. Enable `upload-failure-reports: true` for detailed reports
 
 ### Missing Artifacts

--- a/build-lectures/README.md
+++ b/build-lectures/README.md
@@ -183,7 +183,9 @@ See the [cache actions documentation](../build-jupyter-cache/README.md) for setu
 
 - `-W`: Treat warnings as errors
 - `--keep-going`: meaningful only alongside `-W` — collect every warning-as-error instead of
-  stopping at the first, then exit non-zero at the end of the build. On its own it does nothing.
+  stopping at the first, then exit non-zero at the end of the build. Sphinx ANDs the two flags
+  (`self.keep_going = warningiserror and keep_going`), so without `-W` this flag has no effect
+  at all.
 
 > **Warning:** keep `-W` in any `extra-args` you set.
 >
@@ -232,7 +234,8 @@ extra-args: '-W --keep-going --all'
 1. Check specific notebook in build logs
 2. Run locally: `jb build lectures`
 3. Re-run locally the way CI does — `jb build lectures -W --keep-going` — to see every error that
-   fails the build (`--keep-going` without `-W` reports nothing extra)
+   fails the build (`--keep-going` is inert without `-W`, since Sphinx only honours it when
+   warnings are already being treated as errors)
 4. Enable `upload-failure-reports: true` for detailed reports
 
 ### Missing Artifacts


### PR DESCRIPTION
Items 3 and 4 from #116, plus one harness property that review turned up. No consumer-facing behaviour changes — one CI assertion and two docs corrections.

## Item 3 — `build-fail-guard` accepted any red

The job asserted only that the build step's outcome was `failure`. A build that died on some unrelated `-W` warning satisfies that just as well, so the job could stay green while the property it exists to guard — a failing build fails the step — was broken. It now also requires the staged traceback at `harness/_build/html/reports/broken.err.log` and checks that the log carries the fixture's own assertion message, so the red is provably this job's deliberate `CellExecutionError`.

The `$OUTCOME` check stays first, because a stale `err.log` survives an incremental rebuild that exits 0 — the file existing is not by itself evidence that the build failed. The path is hard-coded rather than globbed on purpose: it is the same path `build-lectures` ships in `upload-failure-reports`, so a jupyter-book layout change goes red here instead of silently producing an empty artifact there.

## Item 4 — the `-W` dependence was recorded nowhere

A code cell that raises is not an error to Jupyter Book. `myst-nb` logs it as a warning and carries on, so `-W` in the `extra-args` default is the only reason a broken lecture fails the build — and `extra-args` **replaces** the default rather than extending it. A consumer who overrides `extra-args` without `-W` gets a published site, an error-report page, and exit 0: green CI over a broken lecture. The README documented what `-W` does but never that it was load-bearing.

The Troubleshooting step that suggested bare `--keep-going` to see all errors is also corrected — without `-W` it reports nothing extra.

## New: "Re-run failed jobs" can never go green on this harness

Not in #116, found while reviewing it. `SALT` is `run_id-run_attempt`. GitHub increments `run_attempt` on a re-run but does **not** re-run already-green jobs, so the seeds stay put while the restore/hit jobs rebuild their fixtures under a new salt and look for caches nobody saved; `fail-on-miss` then fires. Only "Re-run all jobs" works. Every run to date is `attempt=1`, which is why it has never been hit. Recorded in the workflow header rather than "fixed" — dropping `run_attempt` from the salt would let attempt 2 reuse attempt 1's caches and silently invalidate the miss assertions.

## Verification

Both docs claims were checked against a real build rather than reasoned about (jupyter-book 1.0.4.post1 / myst-nb 1.4.0, harness fixture with the same staged failure):

| Build | Exit | `reports/broken.err.log` | Site |
|---|---|---|---|
| `-W --keep-going` | 1 | written | — |
| `--keep-going` only | **0** | written | `broken.html` published |
| `raise_on_error: true`, no `-W` | 1 | **not** written | aborted |

The middle row is the failure mode the new README warning describes. The bottom row is why that warning prefers `-W` over `raise_on_error`.

The new assertion block was extracted from the YAML and run under `bash -e` against the real failed build tree: passes on it, and fails with a useful message when the report is absent or carries a different failure. Workflow still parses (14 jobs, `build-fail-guard` unchanged in shape).

CI is the real check — this PR touches `.github/workflows/test-actions.yml`, so the harness runs on it and `build-fail-guard` exercises the new assertion end to end.

## Not included

#116 items 1, 2 and 5 are unchanged here. Item 1 is blocked on the release that moves `v0`; items 2 and 5 need their premises corrected first, which I'll do on the issue.

Refs #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)