### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-05
+
 ### Added
 - **CI**: Action-level PR harness (`.github/workflows/test-actions.yml`) — the first automated
   tests for the action logic itself, run against the PR's code via `./` local paths. Covers


### PR DESCRIPTION
CHANGELOG-only, matching #113. Ships the two hosted-runner fixes the action harness caught on its first run, plus the harness itself.

## Why minor, not patch

Both changes are bug fixes and no input or output changed shape, so strict semver would say `0.9.1`. Minor is the more honest signal here: `setup-environment`'s conda cache moved from `${CONDA}/envs` to `${CONDA}/envs/<environment-name>`, and `path` is part of the `actions/cache` version — so every existing cache under the old path becomes unreachable the moment `v0` moves, and the first hosted-runner build after that pays one full environment solve. It is self-correcting and one-time, but it is a visible behaviour change rather than a silent fix.

## What consumers actually get

| Fix | Who it affects |
|---|---|
| `build-lectures` no longer fails a *successful* build | Hosted runners only — the `exit` builtin tripped `~/.bash_logout`, whose `clear_console` failure overrode the passed status. Containers have no `~/.bash_logout`. |
| `setup-environment` conda cache can now be restored | Hosted runners only — the cache was rooted at a root-owned parent, so every restore died in tar and reported a miss. |

Both are gated to non-container mode, and all three shipped templates (`ci.yml`, `cache.yml`, `publish.yml`) run in containers. So the default consumer path is unchanged by this release — which is also why neither bug surfaced in production for as long as it did.

## Unblocks

Moving `v0` past this release is what lets `build-jupyter-cache`'s pinned `build-lectures@v0` pick up the exit fix. That retires the `rm -f ~/.bash_logout` workaround in the harness's `bjc-smoke` job — CONTRIBUTING step 5's tripwire, and item 1 of #116. A follow-up PR removes it once the tag has moved, and is self-testing: it touches a covered path, so `bjc-smoke` must go green with `~/.bash_logout` present on the runner.

Refs #116, #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)