### PR TITLE
Retire the ~/.bash_logout workaround now v0 carries the build-lectures fix

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -482,15 +482,6 @@ jobs:
           printf '\n# harness-salt: %s-book\n' "$SALT" >> harness/environment.yml
           printf '%% harness salt: %s-book\n' "$SALT" > harness/lectures/salt.md
 
-      # The internal build-lectures@v0 still ends its login-shell build step
-      # with the exit builtin, which ~/.bash_logout corrupts on hosted runners
-      # (clear_console fails at SHLVL=1 and overrides the status — the bug
-      # fixed in this repo's build-lectures). The pinned @v0 copy can't pick
-      # that fix up until the tag moves, so neutralize the logout hook for
-      # this job. Drop this step once v0 includes the build-lectures fix.
-      - name: Remove ~/.bash_logout (workaround for pre-fix build-lectures@v0)
-        run: rm -f ~/.bash_logout
-
       - name: Build and cache
         id: bjc
         uses: ./build-jupyter-cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,8 @@ should pin an exact `v0.x.y` tag. After the 1.0.0 release, we'll add floating ma
    in `uses:`), so a fix to a sibling action only reaches that chain when `v0` moves in step 3.
    The action harness carries explicit workarounds for that window; grep
    `.github/workflows/test-actions.yml` for `@v0` and remove any that this release resolves.
-   Currently outstanding: the `rm -f ~/.bash_logout` step in `bjc-smoke`, which compensates for
-   the pre-fix `exit`-builtin pattern in `build-lectures@v0`.
+   Currently outstanding: none. Add an entry here whenever you introduce one — a workaround with
+   no entry is one a future releaser will not find.
 
 ### Breaking Changes
 


### PR DESCRIPTION
Discharges CONTRIBUTING release step 5 for v0.10.0, and closes item 1 of #116 — the one knowingly-temporary thing in the tree.

## Why it existed

`build-jupyter-cache` calls `build-lectures` at a pinned `@v0` ref, and GitHub forbids expressions in `uses:`, so that copy could not pick up a sibling fix until the floating tag moved. Until then it still ended its login-shell build step with the `exit` builtin, which `~/.bash_logout` corrupts on hosted runners — `clear_console` fails headless at `SHLVL=1` and its status overrides the one passed to `exit`, turning a successful build into exit 1. `bjc-smoke` neutralised the logout hook to work around it.

`v0` now points at `b3af228` (v0.10.0), which carries `(exit "$BUILD_EXIT_CODE")`. Verified from a fresh clone of the remote tag: the fixed form is present and the old `exit $BUILD_EXIT_CODE` is gone.

## Why removal is coverage, not tidying

While the step was present, the job destroyed the very condition that triggers the bug — so it could not have detected a `bash_logout`-class regression reaching consumers through the pinned chain. Removal restores that.

This PR is its own proof. It touches `.github/workflows/test-actions.yml`, a covered path, so the harness runs on it and `bjc-smoke` must go green with `~/.bash_logout` present on the runner and no workaround. That green run is the evidence that `v0`'s `build-lectures` propagates status correctly through the pinned chain — the first time that has ever been tested.

## The tripwire

CONTRIBUTING step 5's "Currently outstanding" register is blanked rather than left pointing at a step that no longer exists. A stale tripwire is worse than none: the next releaser would grep for something already gone, conclude the instruction was noise, and be that much less likely to trust it when it does matter. The instruction to add an entry when introducing a workaround stays.

## Side effect

The `needs: env-seed` comment on `bjc-smoke` is now accurate. It claimed the internal `setup-environment@v0` could reuse `env-seed`'s conda cache "(same key format today)", but `v0`'s cache path differed from the PR's and `path` is part of the `actions/cache` version — so the keys matched while the versions did not, and reuse never actually happened. v0.10.0 ships the path fix, so it does now. Expect `bjc-smoke` to get slightly faster.

## Remaining `@v0` in the file

Four references remain, all permanent explanatory comments about the structural limitation (lines 36, 39, 465, 472) — not workarounds, and they should stay.

Refs #116, #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)