### PR TITLE
test(containers): make the container fixture able to fail (#108)

### DIFF
--- a/.github/fixtures/mini-lectures/README.md
+++ b/.github/fixtures/mini-lectures/README.md
@@ -3,11 +3,18 @@
 A deliberately tiny lecture repository consumed by the action-level PR harness
 ([`.github/workflows/test-actions.yml`](../../workflows/test-actions.yml), issue #100).
 
-It differs from `containers/quantecon/tests/minimal-jupyter-book` in one
-important way: **it executes a real code cell** (`execute_notebooks: cache`), so
-building it produces a genuine `_build/.jupyter_cache` — the artifact the cache
-actions exist to save and restore. The container fixture builds with execution
-off and cannot exercise that path.
+Both this and `containers/quantecon/tests/minimal-jupyter-book` execute real
+code cells, but they test different things and should stay separate:
+
+| | this fixture | the container fixture |
+|---|---|---|
+| Tests | **action logic** on hosted runners | **image contents** in a container job |
+| Environment | minimal — Python + `jupyter-book` | whatever the image ships |
+| Execution mode | `cache`, so `_build/.jupyter_cache` is genuinely populated | `force` + `raise_on_error` |
+| Optimised for | a fast conda solve | exercising numpy/scipy/pandas/matplotlib and the kaleido→chromium path |
+
+Merging them would make this one slow (a full science stack to solve on every
+harness job) and that one blind to the cache artifact.
 
 The harness copies this directory into the workspace at run time and appends a
 per-run salt (run id + attempt) to `environment.yml` and `lectures/`, so every

--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -11,14 +11,30 @@ on:
       - completed
 
 jobs:
-  test-quantecon:
-    name: Test quantecon (Full)
+  smoke:
+    name: 'Smoke: ${{ matrix.image }}'
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     timeout-minutes: 30
     permissions:
       contents: read
       packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [quantecon, quantecon-build]
+    # A real container job, not `docker run`. The runner mounts an empty
+    # directory at /github/home and forces HOME=/github/home; `docker run` gets
+    # HOME=/root. That is exactly how #85 (kaleido v1 losing its bundled
+    # chromium, provisioned under /root at image build time) passed this
+    # workflow while failing test-containers-lectures.yml, which does use a
+    # container job. Same pattern as that workflow.
+    container:
+      image: ghcr.io/quantecon/${{ matrix.image }}:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -28,96 +44,58 @@ jobs:
           # triggering commit; fall back to github.sha for workflow_dispatch.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull latest container
-        run: docker pull ghcr.io/quantecon/quantecon:latest
-
-      - name: Test XeLaTeX compilation
+      - name: Assert the container-job environment
         run: |
-          cd containers/quantecon
-          docker run --rm -v $(pwd):/workspace -w /workspace/tests \
-            ghcr.io/quantecon/quantecon:latest \
-            bash -c "xelatex test-xelatex.tex && ls -lh test-xelatex.pdf"
+          cat /etc/quantecon-container
+          # If this ever stops being /github/home, the job has silently reverted
+          # to an environment in which #85 could not have surfaced.
+          [ "$HOME" = "/github/home" ] \
+            || { echo "::error::HOME=[$HOME], expected /github/home — this is no longer a container job"; exit 1; }
 
-      - name: Test Jupyter Book HTML build
-        run: |
-          cd containers/quantecon
-          docker run --rm -v $(pwd):/workspace -w /workspace/tests \
-            ghcr.io/quantecon/quantecon:latest \
-            bash -c "cd minimal-jupyter-book && jb build . --builder html"
-          ls -lh tests/minimal-jupyter-book/_build/html/
+      - name: Smoke test
+        run: ./containers/quantecon/tests/smoke-test.sh
 
-      - name: Test Jupyter Book PDF build
-        run: |
-          cd containers/quantecon
-          docker run --rm -v $(pwd):/workspace -w /workspace/tests \
-            ghcr.io/quantecon/quantecon:latest \
-            bash -c "cd minimal-jupyter-book && jb build . --builder pdflatex"
-          ls -lh tests/minimal-jupyter-book/_build/latex/*.pdf
-
-  test-quantecon-build:
-    name: Test quantecon-build (Lean)
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          # Test files must match the commit that built the image. For
-          # workflow_run events checkout defaults to the default branch, not the
-          # triggering commit; fall back to github.sha for workflow_dispatch.
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull latest container
-        run: docker pull ghcr.io/quantecon/quantecon-build:latest
-
-      - name: Check container marker
-        run: |
-          docker run --rm ghcr.io/quantecon/quantecon-build:latest \
-            cat /etc/quantecon-container
-
-      - name: Test XeLaTeX compilation
-        run: |
-          cd containers/quantecon
-          docker run --rm -v $(pwd):/workspace -w /workspace/tests \
-            ghcr.io/quantecon/quantecon-build:latest \
-            bash -c "xelatex test-xelatex.tex && ls -lh test-xelatex.pdf"
-
-      - name: Test Jupyter Book HTML build
-        run: |
-          cd containers/quantecon
-          docker run --rm -v $(pwd):/workspace -w /workspace/tests \
-            ghcr.io/quantecon/quantecon-build:latest \
-            bash -c "cd minimal-jupyter-book && jb build . --builder html"
-          ls -lh tests/minimal-jupyter-book/_build/html/
-
-      - name: Show image size
-        run: |
-          echo "=== Container Image Size ==="
-          docker images ghcr.io/quantecon/quantecon-build:latest --format "quantecon-build (lean): {{.Size}}"
-
-      - name: Upload test artifacts
-        uses: actions/upload-artifact@v7
+      # Runs even if the smoke test failed: a green smoke test whose fixture
+      # cannot fail is the defect #108 was about, so the guard has to report
+      # independently.
+      - name: Self-test (the fixture must be able to fail)
         if: always()
+        run: ./containers/quantecon/tests/smoke-test.sh --self-test
+
+      - name: Upload test outputs
+        if: always()
+        uses: actions/upload-artifact@v7
         with:
-          name: test-outputs-lean
-          path: |
-            containers/quantecon/tests/test-xelatex.pdf
-            containers/quantecon/tests/minimal-jupyter-book/_build/
+          name: smoke-${{ matrix.image }}
+          path: ${{ runner.temp }}/smoke-*/
+          if-no-files-found: warn
+
+  # The old workflow reported image size via `docker images` after a pull. A
+  # container job cannot run docker, so this reads the manifest instead — note
+  # that is COMPRESSED layer size, a different (smaller) number than the old
+  # uncompressed one, so do not compare the two series directly.
+  size:
+    name: 'Image size: ${{ matrix.image }}'
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [quantecon, quantecon-build]
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Report compressed image size
+        run: |
+          docker manifest inspect ghcr.io/quantecon/${{ matrix.image }}:latest \
+            | jq -r '"${{ matrix.image }}: \(([.layers[].size] | add) / 1048576 | floor) MiB compressed"' \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a real action path fails the gate closed instead of silently skipping the suite. `harness-summary`
   now certifies both shapes (all-ran and all-skipped), rejects a vacuous empty job set, and fails
   if the gate and the fan-out disagree. (#116)
+- **CI**: the container smoke tests could not fail. `containers/quantecon/tests/minimal-jupyter-book/`
+  was inert for three independent reasons — `execute_notebooks: "off"`, its one code block was a
+  plain ` ```python ` fence rather than a `{code-cell}`, and it had no jupytext front matter — so an
+  image whose numpy, matplotlib or kaleido was completely broken still produced a green test. It now
+  executes real cells that **assert** on results (a stack that imports but computes wrong answers is
+  exactly what a smoke test should catch), covering numpy/scipy, pandas, a real matplotlib PNG
+  render, and a plotly static export through kaleido — the #85 path. `execute_notebooks: force` plus
+  `raise_on_error: true`, and the build passes `-W`, because a raising cell is otherwise only a
+  warning.
+  `test-container.yml` now runs both images as real `container:` jobs rather than `docker run`. That
+  is not cosmetic: a container job forces `HOME=/github/home` while `docker run` leaves `HOME=/root`,
+  and that difference is precisely why #85 passed these tests while failing the lecture matrix, which
+  does use a container job. The job asserts `HOME` explicitly so a silent revert is caught. A new
+  `--self-test` mode stages a deliberate exception and fails if the build does *not* go red,
+  attributing on captured output rather than `reports/*.err.log` (with `raise_on_error` myst-nb
+  raises before Sphinx writes the report). The lean image also gains pdflatex coverage it never had,
+  and image size is now reported from the manifest — **compressed** layer bytes, a different and
+  smaller number than the previous `docker images` figure, so the two series are not comparable.
+  (#108)
 
 ### Fixed
 - **build-jupyter-cache**: failure alerting **never worked in container mode**, which is the

--- a/TESTING.md
+++ b/TESTING.md
@@ -24,7 +24,9 @@
 
 `.github/workflows/test-actions.yml` tests the composite actions themselves — via `uses: ./<action>` local paths, so it exercises **the code on the PR**, not a released ref. The workflow runs on **every** PR, on pushes to `main`, and on manual dispatch; a `gate` job then decides whether the jobs themselves apply, skipping them for changes that cannot affect the actions. It works that way because a workflow suppressed by a `paths:` filter never publishes a check run at all, which would leave a required `Action harness: all checks` pending forever. This is stage 1 of the two-part design in issue #100; it is the permanent form of the throwaway harness that verified the #104 fix.
 
-Fixtures are salted with `run_id`-`run_attempt` so cache keys are unique per run and miss assertions cannot be polluted by earlier runs. The committed fixture (`.github/fixtures/mini-lectures/`) executes a real code cell, so builds populate a genuine `_build/.jupyter_cache` — The container fixture at `containers/quantecon/tests/minimal-jupyter-book/` also executes cells, but with `force` + `raise_on_error` and against the image's own stack — it tests the image, not the action logic (#108).
+Fixtures are salted with `run_id`-`run_attempt` so cache keys are unique per run and miss assertions cannot be polluted by earlier runs. The committed fixture (`.github/fixtures/mini-lectures/`) executes a real code cell, so builds populate a genuine `_build/.jupyter_cache`.
+
+The container fixture at `containers/quantecon/tests/minimal-jupyter-book/` also executes cells, but with `force` + `raise_on_error` and against the image's own stack. It tests the image; this one tests the action logic (#108).
 
 | Action | Coverage |
 |---|---|

--- a/TESTING.md
+++ b/TESTING.md
@@ -24,7 +24,7 @@
 
 `.github/workflows/test-actions.yml` tests the composite actions themselves — via `uses: ./<action>` local paths, so it exercises **the code on the PR**, not a released ref. The workflow runs on **every** PR, on pushes to `main`, and on manual dispatch; a `gate` job then decides whether the jobs themselves apply, skipping them for changes that cannot affect the actions. It works that way because a workflow suppressed by a `paths:` filter never publishes a check run at all, which would leave a required `Action harness: all checks` pending forever. This is stage 1 of the two-part design in issue #100; it is the permanent form of the throwaway harness that verified the #104 fix.
 
-Fixtures are salted with `run_id`-`run_attempt` so cache keys are unique per run and miss assertions cannot be polluted by earlier runs. The committed fixture (`.github/fixtures/mini-lectures/`) executes a real code cell, so builds populate a genuine `_build/.jupyter_cache` — unlike the container fixture, which builds with execution off.
+Fixtures are salted with `run_id`-`run_attempt` so cache keys are unique per run and miss assertions cannot be polluted by earlier runs. The committed fixture (`.github/fixtures/mini-lectures/`) executes a real code cell, so builds populate a genuine `_build/.jupyter_cache` — The container fixture at `containers/quantecon/tests/minimal-jupyter-book/` also executes cells, but with `force` + `raise_on_error` and against the image's own stack — it tests the image, not the action logic (#108).
 
 | Action | Coverage |
 |---|---|

--- a/containers/quantecon/README.md
+++ b/containers/quantecon/README.md
@@ -236,8 +236,9 @@ The test script will:
 ### Test Files
 
 - `tests/test-xelatex.tex` - Minimal XeLaTeX document testing fonts and unicode
-- `tests/minimal-jupyter-book/` - Minimal Jupyter Book project for build testing
-- `tests/test-container.sh` - Automated test script for Docker container
+- `tests/minimal-jupyter-book/` - Minimal Jupyter Book whose cells actually execute, so a broken science stack fails the build
+- `tests/smoke-test.sh` - What CI runs, inside the image; `--self-test` asserts the fixture can still fail
+- `tests/test-container.sh` - Older automated test script for Docker container
 - `tests/run-local-tests.sh` - Local test script for macOS development
 
 ### Local Testing (macOS)
@@ -253,6 +254,8 @@ cd containers/quantecon/tests
 - MacTeX (for xelatex)
 - jupyter-book (`pip install jupyter-book`)
 - DejaVu Serif fonts (`brew install --cask font-dejavu`)
+- numpy, scipy, pandas, matplotlib, and plotly with a working `kaleido<1.0` — the
+  fixture executes its cells now, so these are no longer optional
 
 The script runs the same tests as the container test suite locally.
 

--- a/containers/quantecon/tests/minimal-jupyter-book/_config.yml
+++ b/containers/quantecon/tests/minimal-jupyter-book/_config.yml
@@ -3,7 +3,18 @@ author: QuantEcon
 logo: ""
 
 execute:
-  execute_notebooks: "off"
+  # "force", not "off". The point of this fixture is to run the image's Python
+  # stack — before #108 it executed nothing at all, so an image whose numpy,
+  # matplotlib or kaleido was completely broken still produced a green
+  # container test.
+  execute_notebooks: "force"
+  # Belt and braces with the `-W` that smoke-test.sh passes. myst-nb reports a
+  # failed cell as a *warning* by default, so without one of these a raising
+  # cell yields a published book and exit 0. Keep BOTH: a typo in this key
+  # (e.g. `raise_on_errors`) is accepted silently by jupyter-book's config
+  # validator, and `-W` is then the only thing still catching a failing cell.
+  raise_on_error: true
+  timeout: 300
 
 latex:
   latex_documents:

--- a/containers/quantecon/tests/minimal-jupyter-book/intro.md
+++ b/containers/quantecon/tests/minimal-jupyter-book/intro.md
@@ -64,6 +64,7 @@ what exercises the backend and the font stack.
 import io
 import matplotlib
 import matplotlib.pyplot as plt
+import numpy as np  # imported here too: keeps a failure here attributable to matplotlib
 
 fig, ax = plt.subplots(figsize=(4, 2))
 ax.plot(np.linspace(0, 1, 50), np.linspace(0, 1, 50) ** 2)

--- a/containers/quantecon/tests/minimal-jupyter-book/intro.md
+++ b/containers/quantecon/tests/minimal-jupyter-book/intro.md
@@ -1,6 +1,24 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
 # Introduction
 
-This is a minimal test book to verify Jupyter Book builds correctly in the container.
+Minimal book used to smoke-test a QuantEcon container image. Every code block
+below is a `{code-cell}`, not a fenced snippet, so it actually runs during the
+build and a broken image fails it.
+
+Each cell **asserts** rather than merely printing. A cell that imports cleanly
+but computes the wrong answer is exactly the sort of breakage a smoke test
+should catch, and printing alone would not.
 
 ## Math Test
 
@@ -10,10 +28,74 @@ $$
 E = mc^2
 $$
 
-## Code Test
+## Numerical stack
 
-```python
+```{code-cell} python3
 import numpy as np
-x = np.array([1, 2, 3])
-print(x)
+import scipy.linalg as sla
+
+A = np.array([[2.0, 1.0], [1.0, 3.0]])
+eigvals = np.sort(sla.eigvalsh(A))
+
+# Exact: (5 ± √5)/2
+expected = np.sort([(5 - np.sqrt(5)) / 2, (5 + np.sqrt(5)) / 2])
+assert np.allclose(eigvals, expected), f"eigenvalues wrong: {eigvals} != {expected}"
+print(f"numpy {np.__version__}: eigenvalues {eigvals}")
+```
+
+## Dataframes
+
+```{code-cell} python3
+import pandas as pd
+
+df = pd.DataFrame({"g": ["a", "a", "b"], "x": [1.0, 3.0, 5.0]})
+means = df.groupby("g")["x"].mean()
+
+assert means["a"] == 2.0 and means["b"] == 5.0, f"groupby wrong: {means.to_dict()}"
+print(f"pandas {pd.__version__}: group means {means.to_dict()}")
+```
+
+## Matplotlib rendering
+
+Renders to a real PNG buffer rather than just constructing a figure — that is
+what exercises the backend and the font stack.
+
+```{code-cell} python3
+import io
+import matplotlib
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots(figsize=(4, 2))
+ax.plot(np.linspace(0, 1, 50), np.linspace(0, 1, 50) ** 2)
+ax.set_title("smoke test")
+
+buf = io.BytesIO()
+fig.savefig(buf, format="png")
+png = buf.getvalue()
+
+assert png.startswith(b"\x89PNG"), "matplotlib did not produce a PNG"
+assert len(png) > 1000, f"matplotlib PNG suspiciously small ({len(png)} bytes)"
+print(f"matplotlib {matplotlib.__version__}: rendered {len(png)} byte PNG")
+plt.close(fig)
+```
+
+## Plotly static export (kaleido → chromium)
+
+The highest-value cell here. This is the path that broke in #85: kaleido v1
+dropped its bundled chromium, and because a GitHub Actions `container:` job
+forces `HOME=/github/home` rather than `/root`, a chromium provisioned under
+`/root` at image build time became unreachable at run time. Both images pin
+`kaleido<1.0` for exactly that reason — this cell is what would notice if the
+pin were lost or the resolved chromium moved again.
+
+```{code-cell} python3
+import plotly
+import plotly.graph_objects as go
+
+fig = go.Figure(go.Scatter(x=[1, 2, 3], y=[1, 4, 9]))
+img = fig.to_image(format="png")
+
+assert img.startswith(b"\x89PNG"), "plotly/kaleido did not produce a PNG"
+assert len(img) > 1000, f"plotly PNG suspiciously small ({len(img)} bytes)"
+print(f"plotly {plotly.__version__}: kaleido exported {len(img)} byte PNG")
 ```

--- a/containers/quantecon/tests/run-local-tests.sh
+++ b/containers/quantecon/tests/run-local-tests.sh
@@ -2,7 +2,7 @@
 # Local test script for replicating container tests on macOS ARM
 # Run from the tests/ directory
 
-set -e
+set -euo pipefail
 
 echo "=============================================="
 echo "LOCAL TEST SUITE"
@@ -14,6 +14,25 @@ echo "Checking prerequisites..."
 command -v xelatex >/dev/null 2>&1 || { echo "ERROR: xelatex not found. Install MacTeX."; exit 1; }
 command -v jupyter-book >/dev/null 2>&1 || { echo "ERROR: jupyter-book not found. Install with: pip install jupyter-book"; exit 1; }
 command -v fc-list >/dev/null 2>&1 || { echo "WARNING: fc-list not found. Install fontconfig with: brew install fontconfig"; }
+
+# The fixture executes real cells (#108), so the book no longer builds with
+# jupyter-book alone. Check the stack up front rather than failing mid-build
+# with a CellExecutionError that looks like a fixture bug.
+python -c "import numpy, scipy, pandas, matplotlib, plotly" 2>/dev/null || {
+  echo "ERROR: the smoke fixture needs numpy, scipy, pandas, matplotlib and plotly."
+  echo "       Install them, or run the real test inside the image:"
+  echo "         docker run --rm -v \$(pwd)/../../..:/w -w /w ghcr.io/quantecon/quantecon:latest \\"
+  echo "           ./containers/quantecon/tests/smoke-test.sh"
+  echo "       (note: docker run gives HOME=/root, so it will NOT reproduce the"
+  echo "        #85 kaleido/chromium path that a container: job exercises)"
+  exit 1
+}
+python -c "import plotly.graph_objects as go; go.Figure().to_image(format='png')" >/dev/null 2>&1 || {
+  echo "ERROR: plotly static export (kaleido) is not working locally."
+  echo "       Install kaleido<1.0, or run the test inside the image (see above)."
+  exit 1
+}
+echo "✓ python stack available (numpy/scipy/pandas/matplotlib/plotly+kaleido)"
 
 echo "✓ xelatex found: $(xelatex --version | head -1)"
 echo "✓ jupyter-book found: $(jupyter-book --version)"

--- a/containers/quantecon/tests/run-local-tests.sh
+++ b/containers/quantecon/tests/run-local-tests.sh
@@ -18,7 +18,14 @@ command -v fc-list >/dev/null 2>&1 || { echo "WARNING: fc-list not found. Instal
 # The fixture executes real cells (#108), so the book no longer builds with
 # jupyter-book alone. Check the stack up front rather than failing mid-build
 # with a CellExecutionError that looks like a fixture bug.
-python -c "import numpy, scipy, pandas, matplotlib, plotly" 2>/dev/null || {
+# Resolve an interpreter first — checking with `command -v` like the prereqs
+# above. Many macOS setups have only python3, and running a bare `python` there
+# would report a missing science stack when the real problem is no python.
+PY_BIN="$(command -v python3 || command -v python || true)"
+[ -n "$PY_BIN" ] || { echo "ERROR: no python3/python on PATH."; exit 1; }
+echo "✓ python found: $PY_BIN ($("$PY_BIN" --version 2>&1))"
+
+"$PY_BIN" -c "import numpy, scipy, pandas, matplotlib, plotly" 2>/dev/null || {
   echo "ERROR: the smoke fixture needs numpy, scipy, pandas, matplotlib and plotly."
   echo "       Install them, or run the real test inside the image:"
   echo "         docker run --rm -v \$(pwd)/../../..:/w -w /w ghcr.io/quantecon/quantecon:latest \\"
@@ -27,7 +34,7 @@ python -c "import numpy, scipy, pandas, matplotlib, plotly" 2>/dev/null || {
   echo "        #85 kaleido/chromium path that a container: job exercises)"
   exit 1
 }
-python -c "import plotly.graph_objects as go; go.Figure().to_image(format='png')" >/dev/null 2>&1 || {
+"$PY_BIN" -c "import plotly.graph_objects as go; go.Figure().to_image(format='png')" >/dev/null 2>&1 || {
   echo "ERROR: plotly static export (kaleido) is not working locally."
   echo "       Install kaleido<1.0, or run the test inside the image (see above)."
   exit 1

--- a/containers/quantecon/tests/smoke-test.sh
+++ b/containers/quantecon/tests/smoke-test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Smoke-test the QuantEcon container image this script is running inside.
+#
+#   containers/quantecon/tests/smoke-test.sh              # normal run
+#   containers/quantecon/tests/smoke-test.sh --self-test  # assert the fixture CAN fail
+#
+# Run it from inside a GitHub Actions `container:` job (see
+# .github/workflows/test-container.yml). Do NOT wrap it in `docker run`: the
+# runner mounts an empty directory at /github/home and forces HOME=/github/home,
+# whereas `docker run` leaves HOME=/root. That difference is not cosmetic — it
+# is exactly why #85 (kaleido v1 losing its bundled chromium, provisioned under
+# /root at image build time) passed the old container tests while failing the
+# real lecture matrix, which does use a container job.
+#
+# The --self-test mode exists because the failure this fixture guards against is
+# silence. Before #108 the book executed nothing at all: `execute_notebooks` was
+# "off" and the one code block was a plain ```python fence rather than a
+# {code-cell}, so an image with a completely broken scientific stack still
+# produced a green test. A fixture that cannot fail is worse than no fixture,
+# because it reads as coverage. --self-test stages a deliberate failure and
+# fails if the build does NOT go red.
+set -euo pipefail
+
+MODE="${1:-normal}"
+SENTINEL="SMOKE-SELF-TEST-SENTINEL"
+TESTS_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+# Fresh directory per invocation. Never rm -rf a fixed path: builds write as the
+# container's uid, and reusing a deterministic directory turns cleanup into a
+# permission error that masquerades as a test result.
+WORK="$(mktemp -d "${RUNNER_TEMP:-/tmp}/smoke-XXXXXX")"
+echo "workdir: $WORK"
+echo "HOME:    ${HOME:-unset}"
+
+cp -R "$TESTS_DIR/minimal-jupyter-book" "$WORK/book"
+cp "$TESTS_DIR/test-xelatex.tex" "$WORK/"
+cd "$WORK"
+
+if [ "$MODE" = "--self-test" ]; then
+  printf '\n```{code-cell} python3\nraise RuntimeError("%s")\n```\n' "$SENTINEL" >> "$WORK/book/intro.md"
+fi
+
+echo "== container marker =="
+cat /etc/quantecon-container
+
+if [ "$MODE" != "--self-test" ]; then
+  echo "== xelatex =="
+  xelatex -interaction=nonstopmode test-xelatex.tex
+  ls -lh test-xelatex.pdf
+fi
+
+echo "== jupyter-book html (executes the cells) =="
+set +e
+jb build book --builder html -W --keep-going 2>&1 | tee "$WORK/html.log"
+rc=${PIPESTATUS[0]}
+set -e
+
+if [ "$MODE" = "--self-test" ]; then
+  if [ "$rc" -eq 0 ]; then
+    echo "::error::self-test: a raising {code-cell} did NOT fail the build — the fixture is inert. Check execute.execute_notebooks (must not be \"off\"), execute.raise_on_error, the jupytext front matter, and that cells use {code-cell} rather than a plain \`\`\`python fence."
+    exit 1
+  fi
+  # Attribute the red, for the same reason build-fail-guard does in
+  # test-actions.yml: a non-zero exit is also produced by a bad mount, an OOM,
+  # or an unrelated -W warning, any of which would let this guard pass while the
+  # fixture was in fact inert.
+  #
+  # Unlike build-fail-guard this greps captured stdout rather than
+  # _build/html/reports/*.err.log — with execute.raise_on_error: true myst-nb
+  # raises before Sphinx writes the report, so that file does not exist here.
+  grep -q "$SENTINEL" "$WORK/html.log" || {
+    echo "::error::self-test: the build failed (rc=$rc) but not on the staged exception — the red is not attributable to the fixture."
+    tail -60 "$WORK/html.log"
+    exit 1
+  }
+  echo "✅ self-test: the staged raising cell failed the build (rc=$rc)"
+  exit 0
+fi
+
+[ "$rc" -eq 0 ] || exit "$rc"
+
+echo "== jupyter-book pdflatex =="
+jb build book --builder pdflatex -W --keep-going
+ls -lh book/_build/latex/*.pdf
+
+echo "== OK =="


### PR DESCRIPTION
The container smoke tests could not fail. This is the substance of #108, though the fixture was inert for **three** independent reasons rather than the one the issue names.

## Why it was inert

| # | Cause |
|---|---|
| 1 | `execute_notebooks: "off"` in `_config.yml` |
| 2 | the one code block was a plain ` ```python ` fence, not a `{code-cell}` |
| 3 | no jupytext front matter, so the file was never treated as a notebook at all |

`grep -rn 'code-cell'` over the fixture returned zero hits. An image whose numpy, matplotlib or kaleido was completely broken still produced a green container test.

And fixing only 1 and 2 would **still** not be enough: myst-nb reports a failed cell as a *warning*, so a raising cell yields a published book and exit 0 unless `-W` or `raise_on_error` is set. Both are now set — deliberately, because a typo in the `raise_on_error` key is accepted silently by jupyter-book's config validator, and `-W` is then the only thing still catching a failing cell.

## What it tests now

Cells that **assert** rather than print. A stack that imports cleanly but computes wrong answers is exactly what a smoke test should catch, and printing alone would not.

- numpy/scipy eigenvalues against an exact closed form
- a pandas groupby
- a real matplotlib PNG render (buffer, not just figure construction — that's what exercises the backend and fonts)
- **a plotly static export through kaleido** — the #85 path, and the reason both images pin `kaleido<1.0`

## `container:` jobs, not `docker run`

This is the other half, and it is not cosmetic. A GitHub Actions `container:` job forces `HOME=/github/home`; `docker run` leaves `HOME=/root`. That difference is precisely why **#85 passed these tests while failing `test-containers-lectures.yml`**, which does use a container job — kaleido v1 dropped its bundled chromium, and a chromium provisioned under `/root` at image build time became unreachable at run time.

So both images now run as a real `container:` job matrix, and the job asserts `HOME=/github/home` explicitly so a silent revert to a weaker environment is caught. The lean image also gains pdflatex coverage it never had.

## The self-test

The defect here was *silence* — a fixture that cannot fail reads as coverage. So `smoke-test.sh --self-test` stages a deliberate exception and fails if the build does **not** go red, and it attributes the red rather than accepting any non-zero (which a bad mount, an OOM, or an unrelated `-W` warning would also satisfy).

It greps captured stdout rather than `reports/*.err.log`, unlike `build-fail-guard`. Verified: with `raise_on_error: true` myst-nb raises *before* Sphinx writes the report, so that file does not exist here.

## Verification

Run locally against jupyter-book 1.0.4.post1 / myst-nb 1.4.0, minus the plotly cell (kaleido is not in my local env):

| check | result |
|---|---|
| cells genuinely execute | `numpy 2.3.5: eigenvalues [1.38 3.62]`, `pandas 2.3.3: group means {a: 2.0, b: 5.0}`, `matplotlib 3.10.6: rendered 12311 byte PNG` — all present in the built HTML |
| clean under `-W` | exit 0, zero warnings |
| fixture can fail | staged raise → exit 1 |
| sentinel in captured output | present |
| `reports/` written | **absent** — confirms the stdout-attribution decision |

**The plotly/kaleido cell and the `HOME` assertion can only be verified in CI.** I'll trigger `workflow_dispatch` on this branch before asking for merge — `workflow_run` only fires for workflow files already on the default branch, so that dispatch is the only possible pre-merge gate.

## Deliberately not in scope

- **Directory consolidation.** #108 also proposes unifying three copies of the container-runner logic under `containers/tests/`. Left alone: it would dangle at least six doc references, and this PR is already the behavioural change. Worth a follow-up.
- **`fontpkg: ""`.** Removing it would engage the FreeSerif/fontspec chain that broke in #3 — real added coverage, but a separate and riskier change that I cannot verify locally.
- **Pinning `plotly`.** It is bare in `containers/quantecon-build/environment.yml:49` while `kaleido` is pinned `<1.0`. Since this PR makes `fig.to_image()` load-bearing for CI, a `defaults`-channel plotly bump past the kaleido v0 window would redden the smoke test with no code change here. Pinning it is an image change and belongs in its own PR — flagging it rather than doing it silently.

Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)