### PR TITLE
release: v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-08-07
+
 ### Fixed
 - **`preview-cloudflare`**: PR comments linked the per-deployment hash URL
   (`https://b3a5c314.{project}.pages.dev`) instead of the stable branch alias


### PR DESCRIPTION
Cuts **v0.11.1**. CHANGELOG-only.

## What's in it

One fix: `preview-cloudflare` links the stable `pr-{number}` branch alias in PR comments rather than the per-deployment hash URL (#14, #131). Also fixes a latent bug found alongside it — the old `grep … | head -1` returned whichever `pages.dev` URL wrangler printed first, which meant `deploy-url` was the alias on one wrangler release and the hash on another, with nothing pinning which.

## Why this one needs its own release

Unlike the alerting fixes in v0.11.0, this does **not** reach anyone through the `@v0` chain. `build-jupyter-cache` pulls its siblings in at `@v0`, so moving that tag delivered those fixes; the preview actions are called directly by consumers, so the fix is unreachable until a release exists to point at.

## Patch, not minor — the judgement call

v0.11.0 was a minor because it added an **input**, and this adds an **output** (`deployment-url`), which is strictly the same category of additive surface growth. Called a patch on two grounds, recorded here so the inconsistency is deliberate rather than accidental:

- The changelog files it under **Fixed**, not Added. `deployment-url` exists only to preserve information the fix would otherwise have discarded — the hash URL used to land in `deploy-url` some of the time — rather than to add a capability.
- `deploy-url`'s previous value was **non-deterministic**, varying with the wrangler release the runner happened to install. No consumer could safely have depended on it, so redefining it to always be the alias is a fix rather than a contract change.

Happy to re-cut as v0.12.0 if you read it the other way.

## Release steps after merge

Tag `v0.11.1`, force-move `v0`, publish the GitHub Release. Step 5 is a no-op again — CONTRIBUTING records "Currently outstanding: none", and the `@v0` mentions in `test-actions.yml` are comments about the structural limitation, not workarounds.

## Consumer note

The only consumer of `preview-cloudflare` today is via the preview rollout; `lecture-python.myst` uses `preview-netlify` and is still on exact `@v0.8.0`, so it is unaffected either way. It remains the last exact-pinned consumer — worth moving to `@v0` for consistency, but not urgent, since this fix does not touch its action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)