### PR TITLE
docs(changelog): record the action-gh-release v3.0.2 bump (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,8 +164,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Re-run failed jobs" can never go green on this harness — it bumps `run_attempt`, and so the
   cache salt, without re-running the seed jobs that saved under the old salt. (#116)
 - **publish-gh-pages**: `softprops/action-gh-release` moved to v3.0.2, SHA-pinned as
-  `3d0d9888cb7fd7b750713d6e236d1fcb99157228`. Recorded retrospectively — this shipped in v0.10.0
-  with no changelog entry, which left the v0.9.0 note about v3.0.1 (#94) as the file's last word
+  `3d0d9888cb7fd7b750713d6e236d1fcb99157228`. Recorded retrospectively — it shipped in v0.10.0
+  with no entry at the time, which left the v0.9.0 note about v3.0.1 (#94) as the file's last word
   on the pin while the code had moved past it. (#101)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `harness/_build/html/reports/broken.err.log`. Also recorded in the workflow header that
   "Re-run failed jobs" can never go green on this harness — it bumps `run_attempt`, and so the
   cache salt, without re-running the seed jobs that saved under the old salt. (#116)
+- **publish-gh-pages**: `softprops/action-gh-release` moved to v3.0.2, SHA-pinned as
+  `3d0d9888cb7fd7b750713d6e236d1fcb99157228`. Recorded retrospectively — this shipped in v0.10.0
+  with no changelog entry, which left the v0.9.0 note about v3.0.1 (#94) as the file's last word
+  on the pin while the code had moved past it. (#101)
 
 ### Fixed
 - **build-lectures**: on hosted (non-container) runners, a **successful build failed the step


### PR DESCRIPTION
Fills a gap found while tidying up after the v0.11.1 release.

#101 moved `softprops/action-gh-release` to **v3.0.2** and shipped in **v0.10.0** with no changelog entry. The file's last word on that pin was therefore the v0.9.0 line recording v3.0.1 (#94), while the tree has carried `3d0d9888cb7fd7b750713d6e236d1fcb99157228` — v3.0.2 — ever since. Confirmed against the upstream tag list rather than reading the pin comment: that SHA resolves to `v3.0.2`.

The entry goes into the v0.10.0 **Changed** section where it belongs, in the same style as the #94 entry one release earlier, and says explicitly that it is recorded retrospectively — a silently backfilled entry would hide the fact that a dependency bump can land here without one.

Worth noting for its own sake: this is the second thing this week that drifted because a bump landed without a record. Not worth process changes on one instance, but if it recurs, requiring a changelog line on dependency PRs would be the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)