### PR TITLE
fix(ci): alert when a lecture-matrix leg times out

### DIFF
--- a/.github/workflows/test-containers-lectures.yml
+++ b/.github/workflows/test-containers-lectures.yml
@@ -135,7 +135,23 @@ jobs:
     needs: [test]
     # This workflow runs unattended off the weekly container build. Manual
     # dispatches have someone watching them.
-    if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
+    #
+    # `cancelled` must alert as well as `failure`. A leg killed by
+    # `timeout-minutes` concludes *cancelled*, not failed, so a bare `failure()`
+    # guard is silently disarmed by exactly the regression this matrix exists to
+    # catch — a build that got slow enough to stop finishing. That is how the
+    # 2026-08-03, -08-05 and -08-10 sweeps all went unreported: both
+    # `lecture-python.myst` legs hit the 120-minute ceiling, every other leg
+    # passed, and nothing was filed. Same class as #83 and #103; the same
+    # guard-polarity lesson #123 encoded in `build-jupyter-cache`.
+    #
+    # `always()` is required because `failure()` is false once a needed job is
+    # cancelled. The cost is that a run superseded by the workflow-level
+    # `cancel-in-progress` also reaches here — accepted deliberately: supersedes
+    # are rare on a weekly `workflow_run` trigger, the filed issue is
+    # deduplicated rather than duplicated, and a spare issue is much cheaper
+    # than another three-week silence.
+    if: ${{ always() && github.event_name != 'workflow_dispatch' && (needs.test.result == 'failure' || needs.test.result == 'cancelled') }}
     timeout-minutes: 10
     permissions:
       contents: read

--- a/scripts/create-ci-failure-issue.sh
+++ b/scripts/create-ci-failure-issue.sh
@@ -40,8 +40,21 @@ TITLE="🔴 CI failure: ${GITHUB_WORKFLOW}"
 RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
 # Which legs failed. Needs `actions: read`; degrade to the run link if absent.
+#
+# `cancelled` legs are included and labelled. A job killed by `timeout-minutes`
+# concludes cancelled, not failed, so filtering on failure alone produced an
+# empty list under a "failed" heading — the alert fired with nothing in it.
+# Timings come from the same call so a slow-drift regression is visible in the
+# issue rather than needing a click through to the run.
 FAILED_JOBS="$(gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --json jobs \
-  | jq -r '[.jobs[] | select(.conclusion == "failure") | "- `" + .name + "`"] | join("\n")' \
+  | jq -r '[.jobs[]
+      | select(.conclusion == "failure" or .conclusion == "cancelled")
+      | "- `" + .name + "` — " + .conclusion
+        + (if .startedAt and .completedAt
+           then " after " + (((.completedAt | fromdate) - (.startedAt | fromdate)) / 60 | floor | tostring) + "m"
+           else "" end)
+        + (if .conclusion == "cancelled" then " (timed out, or the run was superseded)" else "" end)]
+    | join("\n")' \
   || true)"
 
 BODY_FILE="$(mktemp)"


### PR DESCRIPTION
The weekly container-validation matrix has been non-green since **2026-08-03** and filed nothing. Found while assessing the July testing audit.

| Sweep | Run | `lecture-python.myst` legs | `Report failure` |
|---|---|---|---|
| 2026-08-03 | [30781114809](https://github.com/QuantEcon/actions/actions/runs/30781114809) | both hit the 120-minute ceiling | skipped |
| 2026-08-05 | [30982565528](https://github.com/QuantEcon/actions/actions/runs/30982565528) | both hit the ceiling | skipped |
| 2026-08-10 | [31350902651](https://github.com/QuantEcon/actions/actions/runs/31350902651) | one at the ceiling, the other 109m | skipped |

Last green sweep was 2026-07-27. No failure issue exists.

## Cause

A job killed by `timeout-minutes` concludes **`cancelled`**, not `failure`. The guard was a bare `failure()`, which is false in that case — so the alerting is silently disarmed by precisely the regression this matrix exists to catch: a build that got slow enough to stop finishing. Every other leg passed, so nothing else signalled either.

This is the third instance of the class in this repo — #103 (nine weeks green-but-cold) and #83 (two months of silent cache failures) — and it is the same guard-polarity lesson #123 encoded in `build-jupyter-cache`, which was never carried across to this workflow.

## Two independent defects, both fixed

**The guard.** Now `always() && … && (needs.test.result == 'failure' || needs.test.result == 'cancelled')`. `always()` is required because `failure()` is false once a needed job is cancelled. The cost is that a run superseded by the workflow-level `cancel-in-progress` also reaches the notify job. That is accepted deliberately and commented in place: supersedes are rare on a weekly `workflow_run` trigger, the filed issue is deduplicated rather than duplicated, and a spare issue is much cheaper than another three-week silence.

**The alert body.** `create-ci-failure-issue.sh` filtered legs on `conclusion == "failure"` alone, so a timed-out leg produced an *empty* list under a "failed" heading — the alert would have fired with nothing in it. It now includes cancelled legs, labels them, and reports each leg's duration, so slow drift is visible in the issue rather than requiring a click into the run. Verified against run 31350902651, where it renders:

    - `lecture-python.myst · quantecon-build` — cancelled after 120m (timed out, or the run was superseded)

`shellcheck` and `actionlint` both clean on the changed files.

## Deliberately not in scope

Why `lecture-python.myst` roughly doubled from ~54m to >120m in two weeks, and the fact that two of six legs now sit within ten minutes of the ceiling. Those are diagnosis and capacity decisions, tracked separately — this PR only restores the signal that should have surfaced them three weeks ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)