### PR TITLE
Retry transient lecture HTML build failures

### DIFF
--- a/.github/workflows/test-containers-lectures.yml
+++ b/.github/workflows/test-containers-lectures.yml
@@ -58,6 +58,8 @@ jobs:
             owner: QuantEcon
           - repo: lecture-python-advanced.myst
             owner: QuantEcon
+          - repo: lecture-python-programming
+            owner: QuantEcon
           # TODO: Re-enable after https://github.com/QuantEcon/lecture-jax/issues/284 is resolved
           # lecture-jax requires JAX but doesn't include pip install commands
           # - repo: lecture-jax
@@ -93,6 +95,8 @@ jobs:
 
       # Stage 1: HTML (executes notebooks)
       - name: Build HTML (Execute Notebooks)
+        id: build-html
+        continue-on-error: true
         uses: ./actions-repo/build-lectures
         with:
           source-dir: lecture-repo/lectures
@@ -100,6 +104,19 @@ jobs:
           builder: html
           upload-failure-reports: true
           failure-artifact-name: reports-html-${{ matrix.container }}-${{ matrix.repo.repo }}
+
+      # A transient raw-GitHub 429 can fail one notebook while the successful
+      # executions remain in the Jupyter cache. Retry once so only the failed
+      # notebooks execute again; a second failure still fails the job.
+      - name: Retry HTML build after failure
+        if: steps.build-html.outcome == 'failure'
+        uses: ./actions-repo/build-lectures
+        with:
+          source-dir: lecture-repo/lectures
+          output-dir: lecture-repo
+          builder: html
+          upload-failure-reports: true
+          failure-artifact-name: reports-html-retry-${{ matrix.container }}-${{ matrix.repo.repo }}
 
       # Stage 2: pdflatex (reuses cached notebooks from HTML build)
       - name: Build PDF (No Execution)

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@
 
 | Repository | quantecon-build | quantecon | Status |
 |------------|-----------------|-----------|--------|
-| lecture-python-programming.myst | 4.6 min | 5.4 min | ✅ Pass |
+| lecture-python-programming | 4.6 min | 5.4 min | ✅ Pass |
 | lecture-python-intro | 11.5 min | 13.4 min | ✅ Pass |
 | lecture-python-advanced.myst | 33.6 min | 35.9 min | ✅ Pass |
 | lecture-python.myst | 60.0 min | 60.0 min | ✅ Pass |
@@ -246,7 +246,7 @@ Before production rollout:
 Pick a test repository or create a fork:
 
 ```bash
-# Option 1: Use lecture-python-programming.myst (lower traffic)
+# Option 1: Use lecture-python-programming (lower traffic)
 # Option 2: Create a fork for testing
 ```
 
@@ -261,7 +261,7 @@ Complete testing with `QuantEcon/test-actions-lecture-intro`, validate all metri
 After successful testing, migrate CPU-based lecture repositories:
 
 1. **lecture-python-intro** (Netlify, similar to test repo)
-2. **lecture-python-programming.myst** (GitHub Pages)
+2. **lecture-python-programming** (GitHub Pages)
 3. **lecture-python-advanced.myst** (GitHub Pages)
 4. **lecture-python.myst** - CPU builds only (defer GPU workflows)
 

--- a/containers/VALIDATION.md
+++ b/containers/VALIDATION.md
@@ -6,7 +6,7 @@ This document records validation test results for the QuantEcon containers acros
 
 Containers are tested by [`test-containers-lectures.yml`](../.github/workflows/test-containers-lectures.yml), which runs after the **Build QuantEcon Containers** workflow completes. Each job builds one lecture repo on one container through the full builder pipeline (HTML → pdflatex → jupyter) **sequentially**, reusing the executed notebooks across builders. Concurrency groups serialize jobs for the same repo to avoid network contention from concurrent dataset downloads; different repos run in parallel.
 
-**Matrix:** 2 containers (`quantecon`, `quantecon-build`) × the QuantEcon lecture repos — `lecture-python-intro`, `lecture-python.myst`, `lecture-python-advanced.myst` (`lecture-jax` is temporarily disabled pending [lecture-jax#284](https://github.com/QuantEcon/lecture-jax/issues/284)).
+**Matrix:** 2 containers (`quantecon`, `quantecon-build`) × the QuantEcon lecture repos — `lecture-python-intro`, `lecture-python.myst`, `lecture-python-advanced.myst`, `lecture-python-programming` (`lecture-jax` is temporarily disabled pending [lecture-jax#284](https://github.com/QuantEcon/lecture-jax/issues/284)).
 
 A companion workflow, [`test-container.yml`](../.github/workflows/test-container.yml), smoke-tests the freshly built images (XeLaTeX compile + a minimal Jupyter Book HTML/PDF build).
 
@@ -22,7 +22,7 @@ A companion workflow, [`test-container.yml`](../.github/workflows/test-container
 | Repository | Lectures | Notes |
 |-----------|----------|-------|
 | `lecture-python-intro` | 46 | Standard, Netlify deployment |
-| `lecture-python-programming.myst` | ~40 | Standard, GitHub Pages |
+| `lecture-python-programming` | ~40 | Standard, GitHub Pages |
 | `lecture-python-advanced.myst` | ~50 | Standard, GitHub Pages |
 | `lecture-python.myst` | ~80 | GPU lectures, GitHub Pages |
 
@@ -39,15 +39,15 @@ A companion workflow, [`test-container.yml`](../.github/workflows/test-container
 | Builder | Repository | quantecon-build (lean) | quantecon (full) |
 |---------|-----------|:---:|:---:|
 | **html** | lecture-python-intro | ✅ 12m | ✅ 13m |
-| | lecture-python-programming.myst | ✅ 5m | ✅ 5m |
+| | lecture-python-programming | ✅ 5m | ✅ 5m |
 | | lecture-python-advanced.myst | ✅ 34m | ✅ 36m |
 | | lecture-python.myst | ✅ 58m | ✅ 100m |
 | **pdflatex** | lecture-python-intro | ✅ 14m | ✅ 14m |
-| | lecture-python-programming.myst | ✅ 6m | ✅ 7m |
+| | lecture-python-programming | ✅ 6m | ✅ 7m |
 | | lecture-python-advanced.myst | ✅ 36m | ✅ 38m |
 | | lecture-python.myst | ✅ 62m | ✅ 63m |
 | **jupyter** | lecture-python-intro | ✅ 12m | ✅ 12m |
-| | lecture-python-programming.myst | ✅ 4m | ✅ 5m |
+| | lecture-python-programming | ✅ 4m | ✅ 5m |
 | | lecture-python-advanced.myst | ✅ 34m | ✅ 35m |
 | | lecture-python.myst | ✅ 58m | ✅ 58m |
 


### PR DESCRIPTION
## What Problem This Solves

The lecture container matrix can fail non-deterministically when concurrent builds receive a transient HTTP 429 from raw GitHub. The matrix also no longer included `lecture-python-programming`, while the validation documentation still described four repositories.

Fixes QuantEcon/actions#102.

## Why This Change Was Made

- Mark the first HTML build step with an ID and allow it to fail temporarily.
- Retry the HTML build once only when the first attempt fails. The existing Jupyter cache means successful notebook executions are reused.
- Use a distinct failure artifact name for the retry to avoid an artifact-name collision.
- Leave the retry without `continue-on-error`, so a persistent failure still fails the matrix job.
- Restore `lecture-python-programming` to the matrix and correct its repository name in the validation and testing documentation.

## User Impact

A single transient raw-GitHub rate-limit response no longer fails a lecture matrix leg. Persistent build failures remain visible, and all four documented lecture repositories are covered again.

## Evidence

- `actionlint .github/workflows/test-containers-lectures.yml` — passed
- `git diff --check` — passed
- Static assertions verified the build step ID, retry condition, distinct retry artifact name, restored matrix entry, and corrected repository names.

The full container matrix cannot be exercised by a PR because this workflow runs only for `workflow_run` and `workflow_dispatch`. Per the issue acceptance criteria, final runtime validation requires a maintainer `workflow_dispatch` after merge.
